### PR TITLE
Add exception handling to command execution

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -91,6 +91,10 @@ class GooeyApp(QObject):
             lambda i, cmd, args: self.get_widget('statusbar').showMessage(
                 f'Finished `{cmd}`'))
 
+        self._cmdexec.execution_failed.connect(
+            lambda i, cmd, args, ce: self.get_widget('statusbar').showMessage(
+                f'`{cmd}` failed: {ce.format_standard()}'))
+
         # demo actions to execute things for dev-purposes
         self.get_widget('actionRun_stuff').triggered.connect(self.run_stuff)
 

--- a/datalad_gooey/dataladcmd_exec.py
+++ b/datalad_gooey/dataladcmd_exec.py
@@ -75,6 +75,11 @@ class GooeyDataladCmdExec(QObject):
         # enforce return_type='generator' to get the most responsive
         # any command could be
         kwargs['return_type'] = 'generator'
+        # Unless explicitly specified, force result records instead of the
+        # command's default transformation which might give Dataset instances
+        # for example.
+        if 'result_xfm' not in kwargs:
+            kwargs['result_xfm'] = None
         try:
             for res in cmd(**kwargs):
                 self.result_received.emit(res)


### PR DESCRIPTION
Turn exceptions bubbling up from datalad command calls into a signal
(currently being picked up by status bar). Otherwise gooey fails to give
any indication of failure in such case, since the exception is in a
different thread.