### PR TITLE
NF: application icon functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/build
 docs/source/generated
 build/
 dist/
+.DS_Store

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -15,6 +15,7 @@ from PySide6.QtCore import (
 )
 from PySide6.QtGui import (
     QAction,
+    QIcon,
 )
 
 from datalad import cfg as dlcfg
@@ -153,8 +154,19 @@ class GooeyApp(QObject):
             self._populate_dataset_menu)
 
 
+class QtApp(QApplication):
+    # A wrapper around QApplication to provide a single (i.e. deduplicated)
+    # point for setting Qapplication-level properties, such as icons.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Set application icon using base file path as reference
+        package_path = Path(__file__).resolve().parent
+        self.setWindowIcon(QIcon(str(package_path / \
+            'resources/icons/app_icon_32.svg')))
+
+
 def main():
-    qtapp = QApplication(sys.argv)
+    qtapp = QtApp(sys.argv)
     gooey = GooeyApp()
     gooey.main_window.show()
     sys.exit(qtapp.exec())

--- a/datalad_gooey/gooey.py
+++ b/datalad_gooey/gooey.py
@@ -61,10 +61,9 @@ class Gooey(Interface):
     def __call__(path: str = None):
         # local import to keep entrypoint import independent of PySide
         # availability
-        from PySide6.QtWidgets import QApplication
-        from .app import GooeyApp
+        from .app import GooeyApp, QtApp
 
-        qtapp = QApplication(sys.argv)
+        qtapp = QtApp(sys.argv)
         gooey = GooeyApp(path)
         gooey.main_window.show()
 

--- a/datalad_gooey/resources/icons/app_icon_32.svg
+++ b/datalad_gooey/resources/icons/app_icon_32.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="31.999996"
+   height="31.999996"
+   viewBox="0 0 8.4666654 8.4666657"
+   version="1.1"
+   id="svg1884"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="app_icon_32.svg"
+   inkscape:export-filename="/home/aqw/git/datalad.org/new_logo/solo6.png"
+   inkscape:export-xdpi="299.96201"
+   inkscape:export-ydpi="299.96201"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs1878" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.399404"
+     inkscape:cx="15.726562"
+     inkscape:cy="14.27488"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1440"
+     inkscape:window-height="788"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     units="px"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata1881">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-111.77668,57.57928)">
+    <g
+       id="g940">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.0357626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect1013"
+         width="8.4666653"
+         height="8.4666653"
+         x="111.77668"
+         y="-57.579281"
+         rx="1.9466687"
+         ry="1.8649462" />
+      <g
+         id="g1279"
+         transform="matrix(0.02840701,0,0,0.02990846,109.62636,-55.115115)">
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#333333;fill-opacity:1;stroke:none;stroke-width:1.56809px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 218.6056,-46.380098 -22.23511,22.234993 22.6271,22.6270987 h 3.29849 c 11.03936,0 20.87511,2.609563 29.50585,7.8282226 8.63086,5.0179417 15.35368,12.1414947 20.17078,21.3745077 5.01795,9.232897 7.52814,19.870117 7.52814,31.913061 0,11.842226 -2.30831,22.380079 -6.9247,31.612976 -4.61651,9.233009 -11.0411,16.359599 -19.27041,21.377539 -2.94639,1.79655 -6.05244,3.25697 -9.30754,4.41031 2.27146,2.41572 20.36684,17.92277 20.36684,17.92277 l -14.47419,27.11695 c 11.17255,-2.18177 21.54491,-5.71643 31.11381,-10.61215 17.4622,-8.83158 30.91099,-21.27374 40.3446,-37.33104 9.63445,-16.057296 14.45284,-34.423954 14.45284,-55.097642 0,-20.673687 -4.71902,-38.937829 -14.15264,-54.7944091 -9.43361,-16.0572979 -22.68051,-28.5026099 -39.7414,-37.3340709 -16.86005,-8.831461 -36.32955,-13.249116 -58.40837,-13.249116 z"
+           id="path1711-6-2-1"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccsccssscccccsccsc"
+           inkscape:export-xdpi="299.96201"
+           inkscape:export-ydpi="299.96201" />
+        <path
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffa200;fill-opacity:1;stroke:none;stroke-width:1.56809px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 132.57493,-46.380098 V 164.6753 c 0,0 78.41868,0.0233 84.85763,0 6.43894,-0.0233 9.16746,-1.17609 9.16746,-1.17609 L 241.36484,140.4126 217.73649,120.11632 H 187.67246 V -1.5180063 l -10.49272,-10.4957497 -12.13123,-12.131349 -0.007,-0.003 c 0.002,0.0015 11.16846,-11.166014 22.23511,-22.232078 z"
+           id="path1711-6-2-1-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cczcccccccccc"
+           inkscape:export-xdpi="299.96201"
+           inkscape:export-ydpi="299.96201" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This PR aims to address #40 in part. It:
- adds an SVG icon image, white background, rounded corners, 32x32 px
- adds a wrapper around `QtApplication` such that the code can be grouped with the new lines that add the icon and such that the same code can be called from multiple entrypoints.
- updates `.gitignore` for Mac developers

Next steps / help needed:
- this looks okay on a Mac (see snapshot below) but needs some visual testing on other operating systems
- the size needs to be adjusted and I am not sure if/how this can be done parameters to the `QIcon` class, or if it requires a complete set of different icon sizes (i.e. multiple files), or via another method?

<img width="805" alt="Screenshot 2022-09-07 at 14 31 54" src="https://user-images.githubusercontent.com/10141237/188879231-cef544ca-363f-4940-9144-8791ca7632ea.png">

