### PR TITLE
Adds icons and annotate item types, states and availability

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -188,6 +188,7 @@ class GooeyFilesystemBrowser(QObject):
             prev_state = item.data(2, Qt.EditRole)
             if state != prev_state:
                 item.setData(2, Qt.EditRole, state)
+                item.setIcon(2, item._getIcon(state))
                 item.emitDataChanged()
 
     # DONE

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -159,7 +159,7 @@ class GooeyFilesystemBrowser(QObject):
                     # do not run, if there are no relevant paths to inspect
                     self._app.execute_dataladcmd.emit(
                         'status',
-                        dict(dataset=dsroot, path=paths_to_investigate)
+                        dict(dataset=dsroot, path=paths_to_investigate, annex='basic')
                     )
 
         # restart annotation watcher
@@ -177,9 +177,13 @@ class GooeyFilesystemBrowser(QObject):
         if state is None:
             # nothing to show for
             return
+        storage = 'file-annex'
+        annex_key = res.get('key')
+        if annex_key is None:
+            storage = 'file-git'
         self.item_annotation_available.emit(
             self._get_item_from_path(Path(path)),
-            dict(state=state),
+            dict(state=state, storage=storage),
         )
 
     def _annotate_item(self, item, props):
@@ -190,6 +194,12 @@ class GooeyFilesystemBrowser(QObject):
                 item.setData(2, Qt.EditRole, state)
                 item.setIcon(2, item._getIcon(state))
                 item.emitDataChanged()
+        if item.data(1, Qt.EditRole) == 'file':
+            if 'storage' in props:
+                item.setIcon(0, item._getIcon(props['storage']))
+            else: 
+                item.setIcon(0, item._getIcon('file'))
+            item.emitDataChanged()
 
     # DONE
     def _disconnect_status_result_receiver(self, thread, cmdname, args):

--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -4,12 +4,17 @@ from typing import Dict
 from PySide6.QtCore import (
     Qt,
 )
+from PySide6.QtGui import (
+    QIcon,
+)
 from PySide6.QtWidgets import (
     QTreeWidgetItem,
 )
 
 from .fsbrowser_utils import _parse_dir
 
+# package path
+package_path = Path(__file__).resolve().parent
 
 class FSBrowserItem(QTreeWidgetItem):
     PathObjRole = Qt.UserRole + 765
@@ -134,8 +139,27 @@ class FSBrowserItem(QTreeWidgetItem):
         item.setData(0, FSBrowserItem.PathObjRole, path)
         path_type = res['type']
         item.setData(1, Qt.EditRole, path_type)
+        item._setItemIcons(res)
         if path_type in ('directory', 'dataset'):
             # show an expansion indiciator, even when we do not have
             # children in the item yet
             item.setChildIndicatorPolicy(QTreeWidgetItem.ShowIndicator)
         return item
+
+    def _setItemIcons(self, res):
+        # Set 'type' icon
+        self.setIcon(0, self._getIcon(res['type']))
+        # Set other icon types: TODO
+
+    def _getIcon(self, item_type):
+        """Gets icon associated with item type"""
+        icon_mapping = {
+            'dataset': 'dataset-closed',
+            'directory': 'directory-closed',
+            'file': 'file',
+        }
+        icon_name = icon_mapping.get(item_type, None)
+        if icon_name:
+            return QIcon(str(package_path / f'resources/icons/{icon_name}.svg'))
+        else:
+            return None

--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -157,6 +157,8 @@ class FSBrowserItem(QTreeWidgetItem):
             'dataset': 'dataset-closed',
             'directory': 'directory-closed',
             'file': 'file',
+            'untracked': 'untracked',
+            'clean': 'clean',
         }
         icon_name = icon_mapping.get(item_type, None)
         if icon_name:

--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -159,6 +159,7 @@ class FSBrowserItem(QTreeWidgetItem):
             'file': 'file',
             'untracked': 'untracked',
             'clean': 'clean',
+            'modified': 'modified',
         }
         icon_name = icon_mapping.get(item_type, None)
         if icon_name:

--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -148,7 +148,9 @@ class FSBrowserItem(QTreeWidgetItem):
 
     def _setItemIcons(self, res):
         # Set 'type' icon
-        self.setIcon(0, self._getIcon(res['type']))
+        item_type = res['type']
+        if item_type != 'file':
+            self.setIcon(0, self._getIcon(item_type))
         # Set other icon types: TODO
 
     def _getIcon(self, item_type):
@@ -157,12 +159,15 @@ class FSBrowserItem(QTreeWidgetItem):
             'dataset': 'dataset-closed',
             'directory': 'directory-closed',
             'file': 'file',
+            'file-annex': 'file-annex',
+            'file-git': 'file-git',
             'untracked': 'untracked',
             'clean': 'clean',
             'modified': 'modified',
         }
         icon_name = icon_mapping.get(item_type, None)
         if icon_name:
-            return QIcon(str(package_path / f'resources/icons/{icon_name}.svg'))
+            return QIcon(str(
+                package_path / 'resources' / 'icons' / f'{icon_name}.svg'))
         else:
             return None

--- a/datalad_gooey/resources/icons/clean.svg
+++ b/datalad_gooey/resources/icons/clean.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="105.92624mm"
+   height="105.92624mm"
+   viewBox="0 0 105.92625 105.92624"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="clean.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.36265545"
+     inkscape:cx="-198.53555"
+     inkscape:cy="74.450832"
+     inkscape:window-width="1440"
+     inkscape:window-height="786"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-67.51937,82.913354)">
+    <circle
+       style="fill:none;fill-opacity:1;stroke:#107e12;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1270"
+       cx="120.48249"
+       cy="-29.950235"
+       r="42.048401" />
+    <path
+       style="fill:#008000;fill-opacity:1;stroke:#107e12;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 113.52309,-9.7573565 30.8336,-39.2832145"
+       id="path1264-0-6" />
+    <path
+       style="fill:#008000;fill-opacity:1;stroke:#107e12;stroke-width:8;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 96.616215,-24.551631 113.49058,-9.7215586"
+       id="path1264-0-6-7" />
+  </g>
+</svg>

--- a/datalad_gooey/resources/icons/dataset-closed.svg
+++ b/datalad_gooey/resources/icons/dataset-closed.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="141.61745mm"
+   height="122.1239mm"
+   viewBox="0 0 141.61745 122.1239"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="dataset-closed.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.50422278"
+     inkscape:cx="271.70529"
+     inkscape:cy="343.10231"
+     inkscape:window-width="1312"
+     inkscape:window-height="788"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-33.088804,-57.528156)">
+    <path
+       id="rect951-2"
+       style="fill:#ffffff;stroke:#000000;stroke-width:3.707"
+       d="m 48.922805,59.381656 h 43.891528 l 13.199857,14.816666 h 25.3707 27.48736 c 7.7452,0 13.9805,6.141961 13.9805,13.771214 v 76.057804 c 0,7.62925 -6.2353,13.77122 -13.9805,13.77122 H 48.922805 c -7.745198,0 -13.980501,-6.14197 -13.980501,-13.77122 V 73.152869 c 0,-7.629252 6.235303,-13.771213 13.980501,-13.771213 z"
+       sodipodi:nodetypes="scccssssssss" />
+    <g
+       id="g2204"
+       transform="matrix(0.26458333,0,0,0.26458333,36.705455,57.514986)">
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#333333;fill-opacity:1;stroke:none;stroke-width:1.95118px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 240.57915,128.57416 -27.66727,27.66712 28.15502,28.15501 h 7.64778 c 13.73633,0 25.975,3.24709 36.71428,9.7407 10.73942,6.24385 19.10466,15.10772 25.0986,26.59641 6.24386,11.48854 9.36731,24.72448 9.36731,39.70958 0,14.73535 -2.87224,27.84765 -8.61644,39.33619 -5.74435,11.48868 -13.7385,20.35633 -23.97827,26.60019 -3.66621,2.23545 -7.53109,4.05266 -11.58142,5.48777 2.82639,3.00589 25.34256,22.30139 25.34256,22.30139 l -18.01031,33.74176 c 13.90206,-2.71478 26.80844,-7.11298 38.71507,-13.20476 21.72831,-10.98918 38.46271,-26.47102 50.201,-46.4512 11.98819,-19.98017 17.98374,-42.8339 17.98374,-68.55828 0,-25.72437 -5.8719,-48.45054 -17.61021,-68.18096 -11.73828,-19.98018 -28.22146,-35.46594 -49.45042,-46.45498 -20.97905,-10.98903 -45.20504,-16.48594 -72.67783,-16.48594 z"
+         id="path1711-6-2-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsccssscccccsccsc"
+         inkscape:export-xdpi="299.96201"
+         inkscape:export-ydpi="299.96201" />
+      <path
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;line-height:25px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffa200;fill-opacity:1;stroke:none;stroke-width:1.95118px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 142.38936,128.57416 v 262.61731 c 0,0 97.57677,0.029 105.58879,0 8.012,-0.029 11.40711,-1.46341 11.40711,-1.46341 L 277.7572,361.00127 248.35633,335.74651 H 210.9475 V 184.39629 l -13.05614,-13.05991 -15.09496,-15.0951 -0.009,-0.004 c 0.002,0.002 13.89698,-13.89393 27.66726,-27.66349 z"
+         id="path1711-6-2-1-9"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cczcccccccccc"
+         inkscape:export-xdpi="299.96201"
+         inkscape:export-ydpi="299.96201" />
+    </g>
+  </g>
+</svg>

--- a/datalad_gooey/resources/icons/directory-closed.svg
+++ b/datalad_gooey/resources/icons/directory-closed.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="141.61745mm"
+   height="122.1239mm"
+   viewBox="0 0 141.61745 122.1239"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="directory-closed.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.50422278"
+     inkscape:cx="271.70529"
+     inkscape:cy="343.10231"
+     inkscape:window-width="1312"
+     inkscape:window-height="788"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-33.088804,-57.528156)">
+    <path
+       id="rect951-2"
+       style="fill:#ffffff;stroke:#000000;stroke-width:3.707"
+       d="m 48.922805,59.381656 h 43.891528 l 13.199857,14.816666 h 25.3707 27.48736 c 7.7452,0 13.9805,6.141961 13.9805,13.771214 v 76.057804 c 0,7.62925 -6.2353,13.77122 -13.9805,13.77122 H 48.922805 c -7.745198,0 -13.980501,-6.14197 -13.980501,-13.77122 V 73.152869 c 0,-7.629252 6.235303,-13.771213 13.980501,-13.771213 z"
+       sodipodi:nodetypes="scccssssssss" />
+  </g>
+</svg>

--- a/datalad_gooey/resources/icons/file-annex.svg
+++ b/datalad_gooey/resources/icons/file-annex.svg
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="104.05524mm"
+   height="136.88431mm"
+   viewBox="0 0 104.05525 136.88431"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="file-annex.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.51451255"
+     inkscape:cx="134.10752"
+     inkscape:cy="126.33317"
+     inkscape:window-width="1440"
+     inkscape:window-height="786"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-66.592982,-1.6796409)">
+    <path
+       id="rect1151"
+       style="fill:#ffffff;stroke:#000000;stroke-width:3.63246"
+       d="m 82.108633,3.5594599 h 54.948627 l 31.69109,29.3693421 v 90.324578 c 0,7.47586 -6.10994,13.49434 -13.69942,13.49434 H 82.108633 c -7.589478,0 -13.699418,-6.01848 -13.699418,-13.49434 V 17.053801 c 0,-7.475865 6.10994,-13.4943411 13.699418,-13.4943411 z"
+       sodipodi:nodetypes="sccssssss" />
+    <path
+       id="rect1309"
+       style="fill:#ffffff;stroke:#000000;stroke-width:3.49999"
+       d="M 137.1516,5.6664078 166.15994,32.342615 H 137.1516 Z"
+       sodipodi:nodetypes="cccc" />
+    <g
+       id="g2580"
+       transform="matrix(0.29873804,0,0,0.29873804,59.69623,-9.531578)"
+       style="stroke:#ff6584;stroke-opacity:1">
+      <path
+         style="fill:none;stroke:#ff6584;stroke-width:25;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path1186"
+         sodipodi:type="arc"
+         sodipodi:cx="216.08054"
+         sodipodi:cy="297.61853"
+         sodipodi:rx="50.480534"
+         sodipodi:ry="52.038574"
+         sodipodi:start="0.8013443"
+         sodipodi:end="3.8360008"
+         sodipodi:arc-type="arc"
+         sodipodi:open="true"
+         d="m 251.20195,334.99742 a 50.480534,52.038574 0 0 1 -69.45238,0.7724 50.480534,52.038574 0 0 1 -4.45992,-71.45237" />
+      <path
+         style="fill:none;stroke:#ff6584;stroke-width:25;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path1186-5"
+         sodipodi:type="arc"
+         sodipodi:cx="249.81184"
+         sodipodi:cy="263.78821"
+         sodipodi:rx="50.480534"
+         sodipodi:ry="52.038574"
+         sodipodi:start="0.78941297"
+         sodipodi:end="3.8360008"
+         sodipodi:arc-type="arc"
+         sodipodi:open="true"
+         transform="matrix(0.00177559,0.99999842,0.99999842,-0.00177559,0,0)"
+         d="m 285.36338,300.73247 a 50.480534,52.038574 0 0 1 -69.66111,1.41748 50.480534,52.038574 0 0 1 -4.68131,-71.66283" />
+      <path
+         style="fill:none;stroke:#ff6584;stroke-width:25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 251.20195,334.99742 50.03674,-50.16847"
+         id="path1953" />
+    </g>
+    <g
+       id="g2580-3"
+       transform="matrix(-0.29873803,-9.4946255e-5,9.4946255e-5,-0.29873803,176.82897,163.51688)"
+       style="stroke:#ff6584;stroke-opacity:1">
+      <path
+         style="fill:none;stroke:#ff6584;stroke-width:25;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path1186-9"
+         sodipodi:type="arc"
+         sodipodi:cx="216.08054"
+         sodipodi:cy="297.61853"
+         sodipodi:rx="50.480534"
+         sodipodi:ry="52.038574"
+         sodipodi:start="0.8013443"
+         sodipodi:end="3.8360008"
+         sodipodi:arc-type="arc"
+         sodipodi:open="true"
+         d="m 251.20195,334.99742 a 50.480534,52.038574 0 0 1 -69.45238,0.7724 50.480534,52.038574 0 0 1 -4.45992,-71.45237" />
+      <path
+         style="fill:none;stroke:#ff6584;stroke-width:25;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="path1186-5-0"
+         sodipodi:type="arc"
+         sodipodi:cx="249.81184"
+         sodipodi:cy="263.78821"
+         sodipodi:rx="50.480534"
+         sodipodi:ry="52.038574"
+         sodipodi:start="0.78941297"
+         sodipodi:end="3.8360008"
+         sodipodi:arc-type="arc"
+         sodipodi:open="true"
+         transform="matrix(0.00177559,0.99999842,0.99999842,-0.00177559,0,0)"
+         d="m 285.36338,300.73247 a 50.480534,52.038574 0 0 1 -69.66111,1.41748 50.480534,52.038574 0 0 1 -4.68131,-71.66283" />
+      <path
+         style="fill:none;stroke:#ff6584;stroke-width:25;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 251.20195,334.99742 50.03674,-50.16847"
+         id="path1953-5" />
+    </g>
+  </g>
+</svg>

--- a/datalad_gooey/resources/icons/file-git.svg
+++ b/datalad_gooey/resources/icons/file-git.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="104.05524mm"
+   height="136.88431mm"
+   viewBox="0 0 104.05525 136.88431"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="file-git.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.65343758"
+     inkscape:cx="65.805826"
+     inkscape:cy="278.52699"
+     inkscape:window-width="1440"
+     inkscape:window-height="786"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-66.592982,-1.6796409)">
+    <path
+       id="rect1151"
+       style="fill:#ffffff;stroke:#000000;stroke-width:3.63246"
+       d="m 82.150451,3.5594599 h 54.948629 l 31.69109,29.3693421 v 90.324578 c 0,7.47586 -6.10994,13.49434 -13.69942,13.49434 H 82.150451 c -7.589478,0 -13.699418,-6.01848 -13.699418,-13.49434 V 17.053801 c 0,-7.475865 6.10994,-13.4943411 13.699418,-13.4943411 z"
+       sodipodi:nodetypes="sccssssss" />
+    <path
+       fill="#f05133"
+       d="m 153.58016,73.585608 -31.72549,-31.72162 c -1.8254,-1.827062 -4.78846,-1.827062 -6.61616,0 l -6.58745,6.58809 8.35597,8.355969 c 1.94255,-0.655877 4.16912,-0.21612 5.71684,1.331902 1.55575,1.557673 1.99238,3.803236 1.32003,5.752303 l 8.05367,8.053668 c 1.94844,-0.671436 4.19649,-0.237646 5.75231,1.320934 2.17516,2.174515 2.17516,5.698092 0,7.873181 -2.17548,2.175793 -5.69906,2.175793 -7.87574,0 -1.63553,-1.636818 -2.04007,-4.039908 -1.21168,-6.055047 l -7.51093,-7.510933 -6.3e-4,19.764908 c 0.5303,0.26252 1.03075,0.61289 1.47266,1.05288 2.17451,2.17426 2.17451,5.6972 0,7.8751 -2.17516,2.174186 -5.70033,2.174186 -7.8732,0 -2.17482,-2.17771 -2.17482,-5.70065 0,-7.8751 0.53748,-0.53652 1.1594,-0.94261 1.82299,-1.21481 v -19.94858 c -0.66391,-0.271049 -1.2851,-0.674116 -1.82335,-1.21494 -1.64735,-1.646064 -2.04411,-4.063825 -1.19927,-6.086745 L 105.41338,51.68815 83.661859,73.439049 c -1.827646,1.828467 -1.827646,4.791513 0,6.618702 l 31.723591,31.721669 c 1.82642,1.82707 4.78844,1.82707 6.61744,0 L 153.5798,80.207625 c 1.82704,-1.827954 1.82704,-4.791893 0,-6.619339"
+       id="path1012"
+       style="fill:#ffa200;fill-opacity:1;stroke-width:0.637762" />
+    <path
+       id="rect1309"
+       style="fill:#ffffff;stroke:#000000;stroke-width:3.49999"
+       d="M 137.1516,5.6664078 166.15994,32.342615 H 137.1516 Z"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/datalad_gooey/resources/icons/file.svg
+++ b/datalad_gooey/resources/icons/file.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="104.05524mm"
+   height="136.88431mm"
+   viewBox="0 0 104.05525 136.88431"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="file2.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.50422278"
+     inkscape:cx="144.77727"
+     inkscape:cy="553.32684"
+     inkscape:window-width="1312"
+     inkscape:window-height="788"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-66.592982,-1.6796409)">
+    <g
+       id="g1935"
+       transform="matrix(0.26458333,0,0,0.26458333,-46.866443,0.95110713)">
+      <g
+         id="g1713">
+        <path
+           id="rect1151"
+           style="fill:#ffffff;stroke:#000000;stroke-width:13.729"
+           d="M 487.46486,9.8583412 H 695.14473 L 814.92206,120.86058 v 341.38423 c 0,28.25524 -23.09269,51.00223 -51.77733,51.00223 H 487.46486 c -28.68464,0 -51.77733,-22.74699 -51.77733,-51.00223 V 60.860577 c 0,-28.255239 23.09269,-51.0022358 51.77733,-51.0022358 z"
+           sodipodi:nodetypes="sccssssss" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:13.2283;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 523.45044,236.22413 H 727.15915"
+           id="path1264-0" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:13.2283;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 523.45044,295.28017 H 727.15915"
+           id="path1264-0-2" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:13.2283;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 523.45044,354.3362 H 727.15915"
+           id="path1264-0-3" />
+        <path
+           id="rect1309"
+           style="fill:#ffffff;stroke:#000000;stroke-width:13.2283"
+           d="M 695.50128,17.821609 805.13908,118.64507 H 695.50128 Z"
+           sodipodi:nodetypes="cccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/datalad_gooey/resources/icons/modified.svg
+++ b/datalad_gooey/resources/icons/modified.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="105.92624mm"
+   height="105.92624mm"
+   viewBox="0 0 105.92625 105.92624"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="modified.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.28151752"
+     inkscape:cx="223.78714"
+     inkscape:cy="117.22183"
+     inkscape:window-width="1440"
+     inkscape:window-height="786"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-67.51937,82.913354)">
+    <circle
+       style="fill:none;fill-opacity:1;stroke:#ffa200;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1270"
+       cx="120.48249"
+       cy="-29.950235"
+       r="42.048401" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffa200;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 98.158934,-29.950234 h 3.901286"
+       id="path1264-0-6"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffa200;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 118.27097,-29.950234 h 4.43046"
+       id="path1264-0-6-1"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#ffa200;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 138.91218,-29.950234 h 3.90129"
+       id="path1264-0-6-7"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/datalad_gooey/resources/icons/untracked.svg
+++ b/datalad_gooey/resources/icons/untracked.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="105.92624mm"
+   height="105.92624mm"
+   viewBox="0 0 105.92625 105.92624"
+   version="1.1"
+   id="svg2071"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   sodipodi:docname="untracked.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview2073"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="0.44866552"
+     inkscape:cx="33.432478"
+     inkscape:cy="323.18062"
+     inkscape:window-width="1440"
+     inkscape:window-height="786"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2068" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-67.51937,82.913354)">
+    <circle
+       style="fill:none;fill-opacity:1;stroke:#d71809;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path1270"
+       cx="120.48249"
+       cy="-29.950235"
+       r="42.048401" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#d71809;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 95.513099,-29.950234 H 145.45188"
+       id="path1264-0-6" />
+  </g>
+</svg>


### PR DESCRIPTION
This is a PR that currently:
- adds 8 SVG icons:
   - one per item type: dataset, directory, file
   - one per state: clean, untracked, modified
   - one per storage system: git, annex
- displays the appropriate icon per item in the `Name` column, for dataset and directory:
- annotates file storage system based on the result of the `status` call, which now has the added `annex='basic'` flag

TO DO:
- [x] Add icons and code to annotate file location (git vs annex) ~~and availability (local or not)~~
- [x] Add icons and code to annotate item state (currently displayed as text in the `State` column). Thoughts on if this is useful/necessary?

**Note:** The TO DO items are likely dependent on #43 and the time it takes to do `datalad status` calls...