### PR TITLE
Don't put an exception's traceback into the status bar

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -96,7 +96,7 @@ class GooeyApp(QObject):
 
         self._cmdexec.execution_failed.connect(
             lambda i, cmd, args, ce: self.get_widget('statusbar').showMessage(
-                f'`{cmd}` failed: {ce.format_standard()}'))
+                f'`{cmd}` failed: {ce.format_short()}'))
 
         # demo actions to execute things for dev-purposes
         self.get_widget('actionRun_stuff').triggered.connect(self.run_stuff)


### PR DESCRIPTION
The former formatting of an exception from a command execution is not well suited for a one-line status bar. It's meant for printing a human-readable multi-line traceback.
Change to a short formatting that gives just the exception class and its message.

Note, that a traceback woud show up at loglevel 8 anyway via CapturedException's constructor.