### PR TITLE
Insert command group submenues unconditionally, but in right order

### DIFF
--- a/datalad_gooey/dataset_actions.py
+++ b/datalad_gooey/dataset_actions.py
@@ -31,8 +31,6 @@ def add_dataset_actions_to_menu(parent, receiver, menu=None, dataset=None):
 
     menu_lookup = _generate_submenus(menu)
 
-    # prevent reinclusion of the main menu by including it here right away
-    submenus_added = set([menu])
     # iterate over all members of the Dataset class and find the
     # methods that are command interface callables
     for mname in dir(Dataset):
@@ -71,9 +69,19 @@ def add_dataset_actions_to_menu(parent, receiver, menu=None, dataset=None):
         # instead of the main menu
         target_menu = menu_lookup.get(cls, menu)
         target_menu.addAction(action)
-        if target_menu not in submenus_added:
-            menu.insertMenu(group_separator, target_menu)
-            submenus_added.add(target_menu)
+    # add submenus in the order they are included in the lookup to ensure
+    # consistent and sensible sorting. First, find all unique submenus in order
+    unique_submenus = {}
+    for cmdname, cmdgroup in [(cmd, menu_lookup[cmd]) for cmd in menu_lookup]:
+        if cmdgroup in unique_submenus:
+            continue
+        unique_submenus[cmdgroup] = cmdname
+    # then add all possible submenues
+    for subm in unique_submenus.keys():
+        # skip menus without actions
+        if not subm.actions():
+            continue
+        menu.insertMenu(group_separator, subm)
 
 
 def _generate_submenus(menu: QMenu) -> dict:


### PR DESCRIPTION
The dataset method menu shows submenu items corresponding to dataset method groups in an unintuitive order - not whats most useful is at the top, but the group who the first command in an alphabetically sorted list belongs to.  From a UX standpoint, the first group should be the most essential commands. A sensible order of command groups already exists in the menu_lookup, but this order is lost during menu assembly, as the assembly proceeds by alphabetical order of command names (see #34). This change preserves the original order (by adding the submenues in the order they are supposed to be).

![Screenshot from 2022-09-12 14-38-55](https://user-images.githubusercontent.com/29738718/189655744-2e37b608-535b-4878-91c2-602138cb2ea8.png)


Closes #34 