### PR TITLE
Speed-up status annotation (massively) by limiting to subds commits

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -218,7 +218,12 @@ class GooeyFilesystemBrowser(QObject):
                     # do not run, if there are no relevant paths to inspect
                     self._app.execute_dataladcmd.emit(
                         'status',
-                        dict(dataset=dsroot, path=paths_to_investigate, annex='basic')
+                        dict(
+                            dataset=dsroot,
+                            path=paths_to_investigate,
+                            eval_subdataset_state='commit',
+                            annex='basic',
+                        )
                     )
 
         # restart annotation watcher


### PR DESCRIPTION
This prevents subdatasets from being inspected for untracked content (even when the respective directories are not yet expanded).

Effectively, a subdataset annotation (attached to the root directory of a subdataset within a superdataset) now reflects whether the state of the subdataset recorded _within_ the superdataset matches the subdatasets checked-out state, or not.