### PR TITLE
Upgrade command result signaling

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -45,7 +45,7 @@ class GooeyApp(QObject):
         'statusbar': QStatusBar,
     }
 
-    execute_dataladcmd = Signal(str, dict)
+    execute_dataladcmd = Signal(str, dict, dict)
     configure_dataladcmd = Signal(str, dict)
 
     def __init__(self, path: Path = None):

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -223,7 +223,8 @@ class GooeyFilesystemBrowser(QObject):
                             path=paths_to_investigate,
                             eval_subdataset_state='commit',
                             annex='basic',
-                        )
+                        ),
+                        dict(),
                     )
 
         # restart annotation watcher

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -32,8 +32,6 @@ class GooeyFilesystemBrowser(QObject):
 
     # FSBrowserItem
     item_requires_annotation = Signal(FSBrowserItem)
-    # what is annotated, and the properties
-    item_annotation_available = Signal(FSBrowserItem, dict)
 
     # DONE
     def __init__(self, app, path: Path, treewidget: QTreeWidget):
@@ -46,10 +44,6 @@ class GooeyFilesystemBrowser(QObject):
         self._fswatcher = QFileSystemWatcher(parent=app)
         self.item_requires_annotation.connect(
             self._queue_item_for_annotation)
-        # and connect the receiver for an annotation of an item in the
-        # model
-        # TODO
-        self.item_annotation_available.connect(self._annotate_item)
 
         tw.setHeaderLabels(['Name', 'Type', 'State'])
         # established defined sorting order of the tree
@@ -241,7 +235,7 @@ class GooeyFilesystemBrowser(QObject):
                 for child in item.children_():
                     # get type, only annotate non-directory items
                     if child.datalad_type != 'directory':
-                        self.item_annotation_available.emit(
+                        self._annotate_item(
                             child, dict(state='untracked'))
             else:
                 # trigger datalad-status execution
@@ -284,7 +278,7 @@ class GooeyFilesystemBrowser(QObject):
         annex_key = res.get('key')
         if annex_key is None:
             storage = 'file-git'
-        self.item_annotation_available.emit(
+        self._annotate_item(
             self._get_item_from_path(Path(path)),
             dict(state=state, storage=storage),
         )
@@ -300,7 +294,7 @@ class GooeyFilesystemBrowser(QObject):
         if item.data(1, Qt.EditRole) == 'file':
             if 'storage' in props:
                 item.setIcon(0, item._getIcon(props['storage']))
-            else: 
+            else:
                 item.setIcon(0, item._getIcon('file'))
             item.emitDataChanged()
 


### PR DESCRIPTION
This is a compound change, comprised of the following components

- `results_received` is not Signal(Interface, list): Instead of a single
  results, there is no always a list of them reported, and the Interface
  class of the underlying command execution is reported as an indentifier
  to associate result to. The latter is done, because it is not possible
  to connect slots on a per execution basis (see next change), and cheap
  identification must be supported.
- Discontinue on-demand connection (disconnection) of slots. This was
  never working as intended and also caused slowdown, because
  connections are not unique, i.e., a particular connection could be
  (and was made) multiple times, causing a signal to pass to the same
  slot multiple times.
- `GooeyDataladCmdExec` now supports timed result reporting. Passing
  the parameter `preferred_result_interval` will cause results to be
  emitted whenever such interval has passed (whatever number was
  gathered until then).
- `GooeyDataladCmdExec` now excepting arbitrary result property
  overrides. This enables the sender of a command execution request to
  pass arbitrary information _through_ a command execution, and on
  to its own receiver.
- `FSBrowser` now annotates `tree` command execution requests for
  populating tree items with all necessary information to avoid any
  searching of items in the tree widget. This speeds up population of
  large trees from >20min to a few seconds.
- `FSBrowser` now uses a single receiver for command execution results.
  Switching to targeted handlers is based on the new Interface class
  contained in each signal.

Closes #66
Closes #68