### PR TITLE
Custom tree exploration helper

### DIFF
--- a/datalad_gooey/__init__.py
+++ b/datalad_gooey/__init__.py
@@ -10,12 +10,10 @@ lgr = logging.getLogger('datalad.ext.gooey')
 # to be found by datalad
 command_suite = (
     # description of the command suite, displayed in cmdline help
-    "GUI",
+    "Gooey (GUI)",
     [
-        (
-            'datalad_gooey.gooey',
-            'Gooey',
-        ),
+        ('datalad_gooey.gooey', 'Gooey'),
+        ('datalad_gooey.lsdir', 'GooeyLsDir', 'gooey-lsdir', 'gooey_lsdir'),
     ]
 )
 

--- a/datalad_gooey/__init__.py
+++ b/datalad_gooey/__init__.py
@@ -14,6 +14,8 @@ command_suite = (
     [
         ('datalad_gooey.gooey', 'Gooey'),
         ('datalad_gooey.lsdir', 'GooeyLsDir', 'gooey-lsdir', 'gooey_lsdir'),
+        ('datalad_gooey.status_light', 'GooeyStatusLight',
+         'gooey-status-light', 'gooey_status_light'),
     ]
 )
 

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -103,11 +103,11 @@ class GooeyApp(QObject):
         self._fsbrowser._tree.currentItemChanged.connect(
             lambda cur, prev: self._cmdui.reset_form())
 
-    def _setup_ongoing_cmdexec(self, thread_id, cmdname, cmdargs):
+    def _setup_ongoing_cmdexec(self, thread_id, cmdname, cmdargs, exec_params):
         self.get_widget('statusbar').showMessage(f'Started `{cmdname}`')
         self.main_window.setCursor(QCursor(Qt.BusyCursor))
 
-    def _setup_stopped_cmdexec(self, thread_id, cmdname, cmdargs, ce=None):
+    def _setup_stopped_cmdexec(self, thread_id, cmdname, cmdargs, exec_params, ce=None):
         if ce is None:
             self.get_widget('statusbar').showMessage(f'Finished `{cmdname}`')
         else:

--- a/datalad_gooey/dataladcmd_exec.py
+++ b/datalad_gooey/dataladcmd_exec.py
@@ -82,16 +82,26 @@ class GooeyDataladCmdExec(QObject):
         # to PY3.8+ native thread IDs, so let's go with a string identifier
         # right away
         thread_id = str(threading.get_ident())
+        # get functor to execute, resolve name against full API
+        try:
+            cmd = getattr(dlapi, cmdname)
+            cls = get_wrapped_class(cmd)
+        except Exception as e:
+            self.execution_failed.emit(
+                thread_id,
+                cmdname,
+                cmdkwargs,
+                exec_params,
+                CapturedException(e),
+            )
+            return
+
         self.execution_started.emit(
             thread_id,
             cmdname,
             cmdkwargs,
             exec_params,
         )
-        # get functor to execute, resolve name against full API
-        cmd = getattr(dlapi, cmdname)
-        cls = get_wrapped_class(cmd)
-
         # enforce return_type='generator' to get the most responsive
         # any command could be
         cmdkwargs['return_type'] = 'generator'

--- a/datalad_gooey/dataladcmd_exec.py
+++ b/datalad_gooey/dataladcmd_exec.py
@@ -25,8 +25,8 @@ class GooeyDataladCmdExec(QObject):
     and Qt-signal result reporting
     """
     # thread_id, cmdname, cmdargs/kwargs
-    execution_started = Signal(str, str, dict)
-    execution_finished = Signal(str, str, dict)
+    execution_started = Signal(str, str, dict, dict)
+    execution_finished = Signal(str, str, dict, dict)
     # thread_id, cmdname, cmdargs/kwargs, CapturedException
     execution_failed = Signal(str, str, dict, CapturedException)
     results_received = Signal(Interface, list)
@@ -86,6 +86,7 @@ class GooeyDataladCmdExec(QObject):
             thread_id,
             cmdname,
             cmdkwargs,
+            exec_params,
         )
         # get functor to execute, resolve name against full API
         cmd = getattr(dlapi, cmdname)
@@ -123,6 +124,7 @@ class GooeyDataladCmdExec(QObject):
                 thread_id,
                 cmdname,
                 cmdkwargs,
+                exec_params,
                 ce
             )
         else:
@@ -132,6 +134,7 @@ class GooeyDataladCmdExec(QObject):
                 thread_id,
                 cmdname,
                 cmdkwargs,
+                exec_params,
             )
 
     @property

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -195,15 +195,10 @@ class GooeyFilesystemBrowser(QObject):
     def _get_item_from_trace(self, root: FSBrowserItem, trace: List):
         item = root
         for p in trace:
-            found = False
-            for ci in range(item.childCount()):
-                child = item.child(ci)
-                if p == child.data(0, Qt.EditRole):
-                    item = child
-                    found = True
-                    break
-            if not found:
+            item = item[p]
+            if item is None:
                 raise ValueError(f'Cannot find item for {trace}')
+            continue
         return item
 
     def _queue_item_for_annotation(self, item):

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -16,13 +16,13 @@ from PySide6.QtWidgets import (
     QTreeWidget,
 )
 
-from datalad.core.local.status import Status
 from datalad.interface.base import Interface
 from datalad.utils import get_dataset_root
 
 from .dataset_actions import add_dataset_actions_to_menu
 from .fsbrowser_item import FSBrowserItem
 from .lsdir import GooeyLsDir
+from .status_light import GooeyStatusLight
 
 lgr = logging.getLogger('datalad.gooey.fsbrowser')
 
@@ -118,7 +118,7 @@ class GooeyFilesystemBrowser(QObject):
         res_handler = None
         if cls == GooeyLsDir:
             res_handler = self._lsdir_result_receiver
-        elif cls == Status:
+        elif cls == GooeyStatusLight:
             res_handler = self._status_result_receiver
         else:
             raise NotImplementedError(
@@ -247,7 +247,7 @@ class GooeyFilesystemBrowser(QObject):
                         self._annotate_item(
                             child, dict(state='untracked'))
             else:
-                # trigger datalad-status execution
+                # trigger datalad-gooey-status-light execution
                 # giving the target directory as a `path` argument should
                 # avoid undesired recursion into subDIRECTORIES
                 paths_to_investigate = [
@@ -258,18 +258,17 @@ class GooeyFilesystemBrowser(QObject):
                 if paths_to_investigate:
                     # do not run, if there are no relevant paths to inspect
                     self._app.execute_dataladcmd.emit(
-                        'status',
+                        'gooey_status_light',
                         dict(
                             dataset=dsroot,
-                            path=paths_to_investigate,
-                            eval_subdataset_state='commit',
-                            annex='basic',
+                            path=[ipath],
+                            #annex='basic',
                             result_renderer='disabled',
                             on_failure='ignore',
                             return_type='generator',
                         ),
                         dict(
-                            preferred_result_interval=.5,
+                            preferred_result_interval=3.0,
                             result_override=dict(
                                 gooey_parent_item=item,
                             ),

--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -86,12 +86,12 @@ class FSBrowserItem(QTreeWidgetItem):
             include_files=include_files
         )
         if root:
-            root = cls.from_tree_result(next(gen), parent=parent)
+            root = cls.from_lsdir_result(next(gen), parent=parent)
         else:
             next(gen)
             root = parent
         children = [
-            cls.from_tree_result(r, parent=root) for r in gen
+            cls.from_lsdir_result(r, parent=root) for r in gen
         ]
         if children:
             root.addChildren(children)
@@ -99,7 +99,7 @@ class FSBrowserItem(QTreeWidgetItem):
         return root
 
     @classmethod
-    def from_tree_result(cls, res: Dict, parent=None):
+    def from_lsdir_result(cls, res: Dict, parent=None):
         item = FSBrowserItem(parent=parent)
         path = Path(res['path'])
         item.setData(0, FSBrowserItem.PathObjRole, path)
@@ -127,15 +127,18 @@ class FSBrowserItem(QTreeWidgetItem):
             'file': 'file',
             'file-annex': 'file-annex',
             'file-git': 'file-git',
+            # opportunistic guess?
+            'symlink': 'file-annex',
             'untracked': 'untracked',
             'clean': 'clean',
             'modified': 'modified',
             'deleted': 'untracked',
             'unknown': 'untracked',
+            'added': 'modified',
         }
         icon_name = icon_mapping.get(item_type, None)
         if icon_name:
             return QIcon(str(
                 package_path / 'resources' / 'icons' / f'{icon_name}.svg'))
         else:
-            raise NotImplementedError(f"Unkown item type {item_type}")
+            raise NotImplementedError(f"Unknown item type {item_type}")

--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -16,14 +16,17 @@ from .fsbrowser_utils import _parse_dir
 # package path
 package_path = Path(__file__).resolve().parent
 
+
 class FSBrowserItem(QTreeWidgetItem):
     PathObjRole = Qt.UserRole + 765
 
     def __init__(self, parent=None):
+        # DO NOT USE DIRECTLY, GO THROUGH from_lsdir_result()
         super().__init__(
             parent,
             type=QTreeWidgetItem.UserType + 145,
         )
+        self._child_lookup = None
 
     def __str__(self):
         return f'FSBrowserItem<{self.pathobj}>'
@@ -47,6 +50,23 @@ class FSBrowserItem(QTreeWidgetItem):
             return self.pathobj.name
         # fall back on default implementation
         return super().data(column, role)
+
+    def __getitem__(self, name: str):
+        if self._child_lookup is None:
+            self._child_lookup = {
+                child.data(0, Qt.EditRole): child
+                for child in self.children_()
+            }
+        return self._child_lookup.get(name)
+
+    def _register_child(self, name, item):
+        if self._child_lookup is None:
+            self._child_lookup = {}
+        self._child_lookup[name] = item
+
+    def removeChild(self, item):
+        super().removeChild(item)
+        del self._child_lookup[item.pathobj.name]
 
     def children_(self):
         # get all pointers to children at once, other wise removing
@@ -102,6 +122,8 @@ class FSBrowserItem(QTreeWidgetItem):
     def from_lsdir_result(cls, res: Dict, parent=None):
         item = FSBrowserItem(parent=parent)
         path = Path(res['path'])
+        if hasattr(parent, '_register_child'):
+            parent._register_child(path.name, item)
         item.setData(0, FSBrowserItem.PathObjRole, path)
         path_type = res['type']
         item.setData(1, Qt.EditRole, path_type)

--- a/datalad_gooey/status_light.py
+++ b/datalad_gooey/status_light.py
@@ -1,0 +1,262 @@
+"""DataLad GUI status helper"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+from pathlib import (
+    Path,
+    PurePosixPath,
+)
+
+from datalad.interface.base import Interface
+from datalad.interface.base import build_doc
+from datalad.support.param import Parameter
+from datalad.interface.utils import eval_results
+from datalad.distribution.dataset import (
+    EnsureDataset,
+    resolve_path,
+    require_dataset,
+)
+
+from datalad.support.constraints import (
+    EnsureNone,
+)
+from datalad.utils import ensure_list
+
+from .lsdir import GooeyLsDir
+
+lgr = logging.getLogger('datalad.ext.gooey.status_light')
+
+
+@build_doc
+class GooeyStatusLight(Interface):
+    """DataLad GUI helper
+    """
+    # parameters of the command, must be exhaustive
+    _params_ = dict(
+        dataset=Parameter(
+            args=("-d", "--dataset"),
+            doc="""specify the dataset to query.  If
+            no dataset is given, an attempt is made to identify the dataset
+            based on the current working directory""",
+            constraints=EnsureDataset() | EnsureNone()),
+        path=Parameter(
+            args=("path", ),
+            doc="""""",
+        )
+    )
+
+    @staticmethod
+    @eval_results
+    def __call__(dataset=None, path: Path or str or None = None):
+        # This needs to be keep simple and as fast as anyhow possible.
+        # anything that is not absolutely crucial to have should have
+        # an inexpensive switch to turn it off (or be off by default.
+        # This command is an internal helper of gooey, it has no ambition
+        # to generalize, although the components it uses internally
+        # might have applicability in a broader scope.
+
+        # - this takes a single path as a mandatory argument
+        # TODO must be absolute?
+        # - this path must be a directory, if it exists
+        # - this directory can be inside or outside of a dataset
+        # - a result is returned for each item inside that is considered
+        #   "relevant" for gooey (ie. no content inside `.git` or `.git` itself
+        #   etc.
+
+        ds = require_dataset(
+            dataset,
+            # in-principle a good thing, but off for speed
+            check_installed=False,
+            purpose='report status',
+        )
+        repo = ds.repo
+        repo_path = repo.pathobj
+        # normalize paths according to standard datalad rules
+        paths = [resolve_path(p, dataset) for p in ensure_list(path)]
+        # recode paths with repo reference for low-level API
+        repo_paths = [repo_path / p.relative_to(ds.pathobj) for p in paths]
+
+        assert len(paths) == 1
+
+        # mapping:: repo_path -> current type
+        modified = _get_worktree_modifications(
+            repo,
+            # put in repo paths!!
+            repo_paths,
+        )
+        # put in repo paths!!
+        untracked = _get_untracked(repo, repo_paths)
+
+        class _NoValue:
+            pass
+
+        for r in GooeyLsDir.__call__(
+                # we put in repo paths! match against those!
+                repo_paths[0],
+                return_type='generator',
+                on_failure='ignore',
+                result_renderer='disabled'):
+            # the status mapping use Path objects
+            path = Path(r['path'])
+            moreprops = dict(
+                action='status',
+                refds=ds.path,
+            )
+            modtype = modified.get(path, _NoValue)
+            if modtype is not _NoValue:
+                # we have a modification
+                moreprops['state'] = \
+                    'deleted' if modtype is None else 'modified'
+                if modtype:
+                    # if it is None (deleted), keep the old one
+                    # as an annotation of what it was previously.
+                    # apply directly, to simplify logic below
+                    r['type'] = modtype
+            if 'state' not in moreprops and r['type'] != 'directory':
+                # there is not really a state for a directory in Git.
+                # assigning one in this annotate-a-single-dir approach
+                # would make the impression that everything underneath
+                # is clean, which we simply do not know
+                # there was no modification detected, so we either
+                # have it clean or untracked
+                moreprops['state'] = \
+                    'untracked' if path in untracked else 'clean'
+            # recode path into the dataset domain
+            moreprops['path'] = str(ds.pathobj / path.relative_to(repo_path))
+            r.update(moreprops)
+            yield r
+
+
+# lifted from https://github.com/datalad/datalad/pull/6797
+# mode identifiers used by Git (ls-files, ls-tree), mapped to
+# type identifiers as used in command results
+GIT_MODE_TYPE_MAP = {
+    '100644': 'file',
+    # we do not distinguish executables
+    '100755': 'file',
+    '040000': 'directory',
+    '120000': 'symlink',
+    '160000': 'dataset',
+}
+
+
+# lifted from https://github.com/datalad/datalad/pull/6797
+def _get_worktree_modifications(self, paths=None):
+    """Report working tree modifications
+
+    Parameters
+    ----------
+    paths : list or None
+      If given, limits the query to the specified paths. To query all
+      paths specify `None`, not an empty list.
+
+    Returns
+    -------
+    dict
+      Mapping of modified Paths to type labels from GIT_MODE_TYPE_MAP.
+      Deleted paths have type `None` assigned.
+    """
+    # because of the way git considers smudge filters in modification
+    # detection we have to consult two commands to get a full picture, see
+    # https://github.com/datalad/datalad/issues/6791#issuecomment-1193145967
+
+    # low-level code cannot handle pathobjs
+    consider_paths = [str(p) for p in paths] if paths else None
+
+    # first ask diff-files which can report typechanges. it gives a list with
+    # interspersed diff info and filenames
+    mod = list(self.call_git_items_(
+        ['diff-files',
+         # without this, diff-files would run a full status (recursively)
+         # but we are at most interested in a subproject commit
+         # change within the scope of this repo
+         '--ignore-submodules=dirty',
+         # hopefully making things faster by turning off features
+         # we would not benefit from (at least for now)
+         '--no-renames',
+         '-z'
+        ],
+        files=consider_paths,
+        sep='\0',
+        read_only=True,
+    ))
+    # convert into a mapping path to type
+    modified = dict(zip(
+        # paths are every other element, starting from the second
+        mod[1::2],
+        # mark `None` for deletions, and take mode reports otherwise
+        # (for simplicity keep leading ':' in prev mode for now)
+        (None if spec.endswith('D') else spec.split(' ', maxsplit=2)[:2]
+         for spec in mod[::2])
+    ))
+    # `diff-files` cannot give us the full answer to "what is modified"
+    # because it won't consider what smudge filters could do, for this
+    # we need `ls-files --modified` to exclude any paths that are not
+    # actually modified
+    modified_files = set(
+        p for p in self.call_git_items_(
+            # we need not look for deleted files, diff-files did that
+            ['ls-files', '-z', '-m'],
+            files=consider_paths,
+            sep='\0',
+            read_only=True,
+        )
+        # skip empty lines
+        if p
+    )
+    modified = {
+        # map to the current type, in case of a typechange
+        # keep None for a deletion
+        k: v if v is None else v[1]
+        for k, v in modified.items()
+        # a deletion
+        if v is None
+        # a typechange, strip the leading ":" for a valid comparison
+        or v[0][1:] != v[1]
+        # a plain modification after running possible smudge filters
+        or k in modified_files
+    }
+    # convenience-map to type labels, leave raw mode if unrecognized
+    # (which really should not happen)
+    modified = {
+        self.pathobj / PurePosixPath(k):
+        GIT_MODE_TYPE_MAP.get(v, v) for k, v in modified.items()
+    }
+    return modified
+
+
+# lifted from https://github.com/datalad/datalad/pull/6797
+def _get_untracked(self, paths=None):
+    """Report untracked content in the working tree
+
+    Parameters
+    ----------
+    paths : list or None
+      If given, limits the query to the specified paths. To query all
+      paths specify `None`, not an empty list.
+
+    Returns
+    -------
+    set
+      of Path objects
+    """
+    # because of the way git considers smudge filters in modification
+    # detection we have to consult two commands to get a full picture, see
+    # https://github.com/datalad/datalad/issues/6791#issuecomment-1193145967
+
+    # low-level code cannot handle pathobjs
+    consider_paths = [str(p) for p in paths] if paths else None
+
+    untracked_files = set(
+        self.pathobj / PurePosixPath(p)
+        for p in self.call_git_items_(
+            ['ls-files', '-z', '-o'],
+            files=consider_paths,
+            sep='\0',
+            read_only=True,
+        )
+        # skip empty lines
+        if p
+    )
+    return untracked_files

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ High-level API commands
 
    gooey
    gooey_lsdir
+   gooey_status_light
 
 
 Command line reference
@@ -27,6 +28,7 @@ Command line reference
 
    generated/man/datalad-gooey
    generated/man/datalad-gooey-lsdir
+   generated/man/datalad-gooey-status-light
 
 
 Indices and tables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ High-level API commands
    :toctree: generated
 
    gooey
+   gooey_lsdir
 
 
 Command line reference
@@ -25,6 +26,7 @@ Command line reference
    :maxdepth: 1
 
    generated/man/datalad-gooey
+   generated/man/datalad-gooey-lsdir
 
 
 Indices and tables


### PR DESCRIPTION
The current implementation based on `datalad tree` is flawed, because it cannot list deleted content (which is likely needed, or a source of confusion in the context of a version control system).

This changeset provides a custom helper for Gooey to perform the required exploration (list the content of a single directory, non-recursively), with type information on all children.

`datalad gooey-lsdir` provides this functionality. it is implemented as a thin wrapper around `git ls-files`, reusing some helpers from datalad-core (which could be better tuned for this purpose).

It is faster than the current `tree`-based implementation, and tons faster than a possible alternative switch to `datalad status`.

The following stats are for listing a directory with 36k annexed files

```
timeit print(len(gooey_lsdir('study_20140724_095117357', result_renderer='disabled')))
...
36401
502 ms ± 60.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

timeit print(len(tree('study_20140724_095117357', include_files=True, depth=1, result_renderer='disabled')))
...
36402
2.48 s ± 295 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

timeit print(len(status('study_20140724_095117357', untracked='all', result_renderer='disabled')))
...
36401
24.1 s ± 858 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Here is listing 1k untracked files in an untracked directory

```
timeit print(len(gooey_lsdir('untracked', result_renderer='disabled')))
...
1000
24.8 ms ± 1.46 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

timeit print(len(tree('untracked', include_files=True, depth=1, result_renderer='disabled')))
...
1001
16 ms ± 2.41 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)

timeit print(len(status('untracked', untracked='all', result_renderer='disabled')))
...
1000
102 ms ± 2 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Due to the way `git ls-files` works, it is impossible to limit the query to just a directory and its immediate content (at least without having to list all files inside it, and knowing them in advance, or from some initial exploration). The demo simulates that case. The listed dir only has few items, but underneath it has both dirs from above (1k untrackedm and 36k clean annexed files). `tree`

```
timeit print(len(gooey_lsdir('.', result_renderer='disabled')))
...
6 # also lists unignored dotfiles
416 ms ± 18.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

timeit print(len(tree('.', include_files=True, depth=1, result_renderer='disabled')))
...
5
32.9 ms ± 2.55 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

timeit print(len(status('.', untracked='all', result_renderer='disabled')))
...
37408
23.4 s ± 333 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Note that in the latter `status` run, the runtime could not be speed up with a path-constraint of a list of files in the immediate directory gathered from the file-system -- because we would (again) not be able to detect deleted files this way.

Right now, this command does not recognize `type=dataset`. I am thinking of keeping it that way (for speed reasons). In the GUI we have to run state annotation afterwards anyways (likely to be done with another internal helper using `git diff-files`). This would also have to check whether things are inside a dataset, and could provide respective type annotation.

Alternative, we could explore to perform this all in one go. https://github.com/datalad/datalad/pull/6797 has an implementation that combines `ls-files` with `diff-files` to make this happen. It did not make it into core, but it can live here.

Closes datalad/datalad-gooey#75

TODO

- [x] The current implementation uses `ls-files -o --directory` to also show subdirectories with only untracked content. However, the same parameterization prevents listing the content in such directories.