### PR TITLE
Unify command execution Signals

### DIFF
--- a/datalad_gooey/dataladcmd_exec.py
+++ b/datalad_gooey/dataladcmd_exec.py
@@ -57,6 +57,8 @@ class GooeyDataladCmdExec(QObject):
                 exec_params: Dict or None = None):
         if kwargs is None:
             kwargs = dict()
+        if exec_params is None:
+            exec_params = dict()
 
         global dlapi
         if dlapi is None:
@@ -71,7 +73,7 @@ class GooeyDataladCmdExec(QObject):
             exec_params,
         ))
 
-    def _cmdexec_thread(self, cmdname, cmdkwargs, exec_params):
+    def _cmdexec_thread(self, cmdname: str, cmdkwargs: Dict, exec_params: Dict):
         """The code is executed in a worker thread"""
         print('EXECINTHREAD', cmdname, cmdkwargs, exec_params)
         preferred_result_interval = exec_params.get(


### PR DESCRIPTION
There are two Signals triggering a datalad command execution: `configure_dataladcmd` and `execute_dataladcmd`. Definition of the former did not match the latter resulting in `GooeyDataladCmdUI` emmitting a signal that the receiver did not properly handle, b/c it got a `None` where it expects a `dict` leading to an "invisible" `AttributeError`.

Closes #84

There are related questions, though, @mih :

- It appears that the `configure_dataladcmd` is defined twice - in app and `GooeyDataladCmdUI`. Looks to me as if the former isn't used (emitted) anywhere. Is that right and should it therefore be deleted?
- Alternatively to the proposed solution, `_cmdexec_thread` and/or the `execute` slot could get an empty dict as default value. I went for this, because we may want to introduce some command specific entries later on from within `GooeyDataladCmdUI._retrieve_input`. Do you agree?
