### PR TITLE
Implement fast version checking of current DataLad against latest on Pypi.org

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -43,6 +43,8 @@ class GooeyApp(QObject):
         'logViewer': QPlainTextEdit,
         'menuDataset': QMenu,
         'statusbar': QStatusBar,
+        'menuUtilities': QMenu,
+        'actionCheck_for_new_version': QAction,
     }
 
     execute_dataladcmd = Signal(str, dict, dict)
@@ -90,18 +92,18 @@ class GooeyApp(QObject):
         self._cmdexec.execution_started.connect(self._setup_ongoing_cmdexec)
         self._cmdexec.execution_finished.connect(self._setup_stopped_cmdexec)
         self._cmdexec.execution_failed.connect(self._setup_stopped_cmdexec)
-
         # arrange for the dataset menu to populate itself lazily once
         # necessary
         self.get_widget('menuDataset').aboutToShow.connect(self._populate_dataset_menu)
-
         # connect pushbutton clicked signal to clear slot of logViewer
         self.get_widget('clearLogPB').clicked.connect(self.get_widget('logViewer').clear)
-
+        self.main_window.actionCheck_for_new_version.triggered.connect(
+            self._check_new_version)
         # reset the command configuration tab whenever the item selection in
         # tree view changed
         self._fsbrowser._tree.currentItemChanged.connect(
             lambda cur, prev: self._cmdui.reset_form())
+
 
     def _setup_ongoing_cmdexec(self, thread_id, cmdname, cmdargs, exec_params):
         self.get_widget('statusbar').showMessage(f'Started `{cmdname}`')
@@ -150,6 +152,8 @@ class GooeyApp(QObject):
         self.get_widget('menuDataset').aboutToShow.disconnect(
             self._populate_dataset_menu)
 
+    def _check_new_version(self):
+        pass
 
 class QtApp(QApplication):
     # A wrapper around QApplication to provide a single (i.e. deduplicated)

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from outdated import check_outdated
 from PySide6.QtWidgets import (
     QApplication,
     QMenu,
@@ -16,11 +17,13 @@ from PySide6.QtCore import (
     Signal,
 )
 from PySide6.QtGui import (
+    QAction,
     QCursor,
     QIcon,
 )
 
 from datalad import cfg as dlcfg
+from datalad import __version__ as dlversion
 import datalad.ui as dlui
 
 from .utils import load_ui
@@ -153,7 +156,16 @@ class GooeyApp(QObject):
             self._populate_dataset_menu)
 
     def _check_new_version(self):
-        pass
+        self.get_widget('statusbar').showMessage('Checking latest version')
+        is_outdated, latest = check_outdated('datalad', dlversion)
+        if is_outdated:
+            self.get_widget('logViewer').appendPlainText(
+                f'Update-alert: Consider updating DataLad from '
+                f'version {dlversion} to {latest}️')
+        else:
+            self.get_widget('logViewer').appendPlainText(
+                f'Your DataLad version is up to date ✔️')
+        self.get_widget('statusbar').showMessage('Done', timeout=500)
 
 class QtApp(QApplication):
     # A wrapper around QApplication to provide a single (i.e. deduplicated)

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -94,7 +94,7 @@
                <x>0</x>
                <y>0</y>
                <width>381</width>
-               <height>152</height>
+               <height>142</height>
               </rect>
              </property>
             </widget>
@@ -193,7 +193,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuUtilities">
@@ -220,7 +220,7 @@
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionCheck_for_new_version">
    <property name="enabled">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="text">
     <string>Check for new version</string>

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ python_requires = >= 3.7
 install_requires =
     datalad_next >= 0.6.0
     pyside6
+    outdated
 packages = find_namespace:
 include_package_data = True
 


### PR DESCRIPTION
This fixes #81.
Internally, it relies on a small Python library ([outdated](https://github.com/alexmojaki/outdated)), which performs plain requests against Pypi.org for the latest version of a specific software package. This makes the version check independent of the presence
of pip locally, and also much faster.
The outcome of the check is written into the console log.

