### PR TITLE
Add a directory picker before App startup if no path is specified

### DIFF
--- a/datalad_gooey/gooey.py
+++ b/datalad_gooey/gooey.py
@@ -62,8 +62,13 @@ class Gooey(Interface):
         # local import to keep entrypoint import independent of PySide
         # availability
         from .app import GooeyApp, QtApp
-
         qtapp = QtApp(sys.argv)
+        if path is None:
+            from PySide6.QtWidgets import QFileDialog
+            path = QFileDialog.getExistingDirectory(
+                caption="Choose directory or dataset",
+                options=QFileDialog.ShowDirsOnly,
+            )
         gooey = GooeyApp(path)
         gooey.main_window.show()
 


### PR DESCRIPTION
Might be a fix for #97. This is how it looks when no path is given to the gooey command:
![pathpicker](https://user-images.githubusercontent.com/29738718/190585436-0f1b0523-7249-4e29-b792-05253dfe440f.gif)

The dialog is skipped when a path is provided, and an empty path is passed if the user cancels the directory picking.