### PR TITLE
Add a timeout of 1sec to status bar's 'Finished...' message

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -122,7 +122,8 @@ class GooeyApp(QObject):
     def _setup_stopped_cmdexec(
             self, thread_id, cmdname, cmdargs, exec_params, ce=None):
         if ce is None:
-            self.get_widget('statusbar').showMessage(f'Finished `{cmdname}`')
+            self.get_widget('statusbar').showMessage(f'Finished `{cmdname}`',
+                                                     timeout=1000)
         else:
             self.get_widget('statusbar').showMessage(
                 f'`{cmdname}` failed: {ce.format_short()}')


### PR DESCRIPTION
If you consider  #103 a bug, this PR is the fix. It time-outs the Finished... message of successfully ran commands after one second.
Fixes #103 