### PR TITLE
Make Filetree width adjust itself to path length

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import (
 from PySide6.QtWidgets import (
     QMenu,
     QTreeWidget,
+    QHeaderView,
 )
 
 from datalad.interface.base import Interface
@@ -40,7 +41,8 @@ class GooeyFilesystemBrowser(QObject):
 
         tw = treewidget
         # TODO must setColumnNumber()
-
+        # make file tree width resize to path lengths
+        tw.header().setSectionResizeMode(QHeaderView.ResizeToContents)
         self._app = app
         self._fswatcher = QFileSystemWatcher(parent=app)
         self.item_requires_annotation.connect(


### PR DESCRIPTION
This change makes the file tree view expand (and shrink the type and state sections to gain space) to display longer filepaths or file paths in freshly opened subdirectories.
Looks like this:

![gooeyresize](https://user-images.githubusercontent.com/29738718/190713760-63dc1d36-8f9f-4da9-a88f-54d028e1debc.gif)
