### PR TITLE
Simplistic approach to stop a command execution thread

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -95,6 +95,8 @@ class GooeyApp(QObject):
         # and give a visual indication of what exactly is happening
         self._cmdui.configured_dataladcmd.connect(self._render_cmd_call)
 
+        self.get_widget('statusbar').addPermanentWidget(
+            self._cmdexec.activity_widget)
         # connect execution handler signals to the setup methods
         self._cmdexec.execution_started.connect(self._setup_ongoing_cmdexec)
         self._cmdexec.execution_finished.connect(self._setup_stopped_cmdexec)


### PR DESCRIPTION
Whenever a command execution starts, a tool button is shown in the status bar. When clicked that button causes a stop flag to be set in the `GooeyDataladCmdExec`, which causes the execution thread to raise an `InterruptedError` exception when it receives the next command result.

All gather results (up to this point) are captured and emitted. The resulting code path is the same as if the command had crashed on its own.

On exit (forced or natural), the kill button is hidding again.

Right now the implementation can only deal with a single running thread, so it needs to be adjusted, whenever we start supporting more than one.

We likely need to support requesting a manual re-exploration of directories in the file browser now, because user can (and will) interrupt the initial traversal and annotation runs too. And the need to be able to re-request them, after a moment of regret.

Closes datalad/datalad-gooey#31