### PR TITLE
Without a basepath, default to start path/directory pickers from HOME

### DIFF
--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -261,6 +261,9 @@ class PathParamWidget(QWidget, GooeyParamWidgetMixin):
         - `QFileDialog.Directory`
         """
         super().__init__(parent)
+        if basedir is None:
+            from os import getenv
+            basedir = getenv("HOME")
         self._basedir = basedir
         self._pathtype = pathtype
 


### PR DESCRIPTION
Unless instructed otherwise, the path or directory selectors of commands start with CWD, i.e., the path that the Gooey command was started from. When someone navigates into a specific directory and starts the gooey up from there, this is probably expected and helpful.

However, it is not so helpful if one did not navigate into a specific directory and started it up from, e.g., the explorer in Windows. The directory that will be opened up in the path picker can easily be completely unfamiliar to a user, and thus tedious to navigate out of.

Ideally, the path that should be opened is the initially provided/picked directory from App startup. I didn't yet figure out how to propagate this through the App components, though. This change is an intermediate step towards it by opening up the HOME directory of the system by default. This directory should be more easily recognizable, and opening the HOME dir first matches probably quite a few other GUIs