### PR TITLE
Basic UI themeing support

### DIFF
--- a/datalad_gooey/__init__.py
+++ b/datalad_gooey/__init__.py
@@ -31,6 +31,15 @@ register_config(
     type=EnsureChoice('simplified', 'complete'),
     default='simplified',
     scope='global')
+register_config(
+    'datalad.gooey.ui-theme',
+    'Which user interface theme to use in the application',
+    description=\
+    "Besides the standard 'system' theme, additional 'light' and 'dark' "
+    "themes are available, if the `qdarktheme` package is installed.",
+    type=EnsureChoice('system', 'light', 'dark'),
+    default='system',
+    scope='global')
 
 
 from ._version import get_versions

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from pathlib import Path
 from outdated import check_outdated
@@ -33,6 +34,8 @@ from .dataladcmd_ui import GooeyDataladCmdUI
 from .cmd_actions import add_cmd_actions_to_menu
 from .fsbrowser import GooeyFilesystemBrowser
 from .resource_provider import gooey_resources
+
+lgr = logging.getLogger('datalad.ext.gooey.app')
 
 
 class GooeyApp(QObject):
@@ -198,6 +201,12 @@ class GooeyApp(QObject):
             a.triggered.connect(self._set_interface_mode)
             if a.objectName().split('_')[-1] == uimode:
                 a.setDisabled(True)
+        uitheme = dlcfg.obtain('datalad.gooey.ui-theme')
+        menu_theme = menu.findChild(QMenu, 'menuTheme')
+        for a in menu_theme.actions():
+            a.triggered.connect(self._set_ui_theme)
+            if a.objectName().split('_')[-1] == uitheme:
+                a.setDisabled(True)
 
     def _set_interface_mode(self):
         action = self.sender()
@@ -210,17 +219,35 @@ class GooeyApp(QObject):
             'The new interface mode is enabled at the next application start.'
         )
 
+    def _set_ui_theme(self):
+        action = self.sender()
+        uitheme = action.objectName().split('_')[-1]
+        assert uitheme in ('system', 'light', 'dark')
+        dlcfg.set('datalad.gooey.ui-theme', uitheme, scope='global')
+        QMessageBox.information(
+            self.main_window,
+            'Note',
+            'The new interface theme is enabled at the next application start.'
+        )
+
     def _setup_looknfeel(self):
         # set application icon
         qtapp = QApplication.instance()
         qtapp.setWindowIcon(gooey_resources.get_icon('app_icon_32'))
 
-        # go dark, if supported
-        try:
-            import qdarktheme
-            qtapp.setStyleSheet(qdarktheme.load_stylesheet('dark'))
-        except ImportError:
-            pass
+        uitheme = dlcfg.obtain('datalad.gooey.ui-theme')
+        if uitheme not in ('system', 'light', 'dark'):
+            lgr.warning('Unsupported UI theme label %r', uitheme)
+            return
+        if uitheme != 'system':
+            # go custom, if supported
+            try:
+                import qdarktheme
+            except ImportError:
+                lgr.warning('Custom UI theme not supported. '
+                            'Missing `qdarktheme` installation.')
+                return
+            qtapp.setStyleSheet(qdarktheme.load_stylesheet(uitheme))
 
     def _render_cmd_call(self, cmdname, cmdkwargs):
         """Minimalistic Python-like rendering of commands in the log"""

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import (
     QTreeWidget,
     QWidget,
     QMessageBox,
+    QFileDialog,
 )
 from PySide6.QtCore import (
     QObject,
@@ -64,9 +65,19 @@ class GooeyApp(QObject):
         # we cannot handle ANSI coloring
         dlcfg.set('datalad.ui.color', 'off', scope='override', force=True)
 
-        # set default path
+        # setup themeing before the first dialog goes up
+        self._setup_looknfeel()
+
         if not path:
-            path = Path.cwd()
+            # start root path given, ask user
+            path = QFileDialog.getExistingDirectory(
+                caption="Choose directory or dataset",
+                options=QFileDialog.ShowDirsOnly,
+            )
+            if not path:
+                # user aborted root path selection, start in HOME.
+                # HOME is a better choice than CWD in most environments
+                path = Path.home()
 
         self._dlapi = None
         self._path = path
@@ -117,8 +128,6 @@ class GooeyApp(QObject):
             lambda cur, prev: self._cmdui.reset_form())
 
         self._connect_menu_view(self.get_widget('menuView'))
-
-        self._setup_looknfeel()
 
     def _setup_ongoing_cmdexec(self, thread_id, cmdname, cmdargs, exec_params):
         self.get_widget('statusbar').showMessage(f'Started `{cmdname}`')

--- a/datalad_gooey/gooey.py
+++ b/datalad_gooey/gooey.py
@@ -64,13 +64,6 @@ class Gooey(Interface):
         from .app import GooeyApp, QApplication
 
         qtapp = QApplication(sys.argv)
-
-        if path is None:
-            from PySide6.QtWidgets import QFileDialog
-            path = QFileDialog.getExistingDirectory(
-                caption="Choose directory or dataset",
-                options=QFileDialog.ShowDirsOnly,
-            )
         gooey = GooeyApp(path)
         gooey.main_window.show()
 

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -224,7 +224,16 @@
      <addaction name="actionInterfaceMode_simplified"/>
      <addaction name="actionInterfaceMode_complete"/>
     </widget>
+    <widget class="QMenu" name="menuTheme">
+     <property name="title">
+      <string>Theme</string>
+     </property>
+     <addaction name="actionViewTheme_system"/>
+     <addaction name="actionViewTheme_light"/>
+     <addaction name="actionViewTheme_dark"/>
+    </widget>
     <addaction name="menuInterface"/>
+    <addaction name="menuTheme"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDataset"/>
@@ -263,6 +272,21 @@
   <action name="actionInterfaceMode_complete">
    <property name="text">
     <string>Complete</string>
+   </property>
+  </action>
+  <action name="actionViewTheme_system">
+   <property name="text">
+    <string>System</string>
+   </property>
+  </action>
+  <action name="actionViewTheme_light">
+   <property name="text">
+    <string>Light</string>
+   </property>
+  </action>
+  <action name="actionViewTheme_dark">
+   <property name="text">
+    <string>Dark</string>
    </property>
   </action>
  </widget>

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     datalad_next >= 0.6.0
     pyside6
     outdated
+    pyqtdarktheme
 packages = find_namespace:
 include_package_data = True
 


### PR DESCRIPTION
Offer 'system' (no change), and a 'light', and 'dark' theme.

Configurable via menu and `datalad.gooey.ui-theme` config switch.

Closes #133 