### PR TITLE
Introduce signal testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -64,7 +64,7 @@ environment:
     - ID: Ubu20
       DTS: datalad_gooey
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
-      INSTALL_SYSPKGS: python3-virtualenv
+      INSTALL_SYSPKGS: python3-virtualenv xvfb
       # system git-annex is way too old, use better one
       INSTALL_GITANNEX: git-annex -m deb-url --url http://snapshot.debian.org/archive/debian/20210906T204127Z/pool/main/g/git-annex/git-annex_8.20210903-1_amd64.deb
       CODECOV_BINARY: https://uploader.codecov.io/latest/linux/codecov

--- a/.github/workflows/test_crippledfs.yml
+++ b/.github/workflows/test_crippledfs.yml
@@ -16,13 +16,15 @@ jobs:
         #sudo sed -e 's|\(deb.*data\)|#\1|' -e 's|/debian |/debian-devel |' /etc/apt/sources.list.d/neurodebian.sources.list | sudo tee /etc/apt/sources.list.d/neurodebian-devel.sources.list
         sudo apt-get update -qq
         sudo apt-get install eatmydata
-        sudo eatmydata apt-get install git-annex-standalone dosfstools
+        sudo eatmydata apt-get install git-annex-standalone dosfstools xvfb
         # 500 MB VFAT FS in a box
         sudo dd if=/dev/zero of=/crippledfs.img count=500 bs=1M
         sudo mkfs.vfat /crippledfs.img
         # mount
         sudo mkdir /crippledfs
         sudo mount -o "uid=$(id -u),gid=$(id -g)" /crippledfs.img /crippledfs
+    - name: Qt dependencies
+      uses: tlambert03/setup-qt-libs@v1
     - name: Set up environment
       run: |
         git config --global user.email "test@github.land"

--- a/datalad_gooey/tests/test_dataladcmd_exec.py
+++ b/datalad_gooey/tests/test_dataladcmd_exec.py
@@ -1,6 +1,48 @@
+from datalad.tests.utils_pytest import (
+    assert_equal,
+    assert_in,
+    assert_result_count,
+)
 
 from ..dataladcmd_exec import GooeyDataladCmdExec
 
 
-def test_GooeyDataladCmdExec():
-    GooeyDataladCmdExec()
+def test_GooeyDataladCmdExec(qtbot):
+
+    executor = GooeyDataladCmdExec()
+
+    cmd = 'nonsense'
+    with qtbot.waitSignal(executor.execution_failed) as block_for_fail, \
+            qtbot.assertNotEmitted(executor.execution_started), \
+            qtbot.assertNotEmitted(executor.execution_finished), \
+            qtbot.assertNotEmitted(executor.results_received):
+        executor.execute(cmd, {}, {})
+
+    # Note: blocker.args delivers the arguments to the signal
+    assert_equal(block_for_fail.args[1], "nonsense")
+    assert_in("module 'datalad.api' has no attribute 'nonsense'",
+              block_for_fail.args[-1].format_short())
+
+    cmd = 'wtf'
+    # MultSignalBlocker via waitSignals() doesn't "work". It blocks
+    # correctly, but signal args are inaccessible contrary to the pytest-qt
+    # docs. Hence, use the uglier way here:
+    with qtbot.waitSignal(executor.execution_started) as block_start, \
+            qtbot.waitSignal(executor.execution_finished) as block_finish, \
+            qtbot.waitSignal(executor.results_received) as block_result,  \
+            qtbot.assertNotEmitted(executor.execution_failed):
+
+        executor.execute(cmd, {}, {})
+
+    # command
+    assert_equal(block_start.args[1], "wtf")
+    assert_equal(block_finish.args[1], "wtf")
+    # thread_id matches:
+    assert_equal(block_start.args[0], block_finish.args[0])
+    # results received:
+    # command class
+    assert_equal(block_result.args[0].__qualname__,
+                 'WTF')
+    # actual results:
+    res = block_result.args[1]
+    assert_result_count(res, 1, action="wtf", status="ok")

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,8 @@
 # requirements for a development environment
 pytest
 pytest-cov
+pytest-qt
+pytest-xvfb
 coverage
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
This introduces the use of `pytest-qt` (and `xvfb` + `pytest-xvfb` for the CI runs) and enhances the test for command execution with it.
While everything looks fine that way, I am actually not quite sure how it manages to run with the CI builds on windows and mac. However, the logs show that the test in question is clearly executed and passes.

Addressing #48