### PR TITLE
Dynamic command parameter input form

### DIFF
--- a/datalad_gooey/dataladcmd_ui.py
+++ b/datalad_gooey/dataladcmd_ui.py
@@ -105,6 +105,7 @@ class GooeyDataladCmdUI(QObject):
 
     @Slot()
     def _retrieve_input(self):
+        from .param_widgets import _NoValue
         params = dict()
         for i in range(self.pform.rowCount()):
             # the things is wrapped into a QWidgetItem layout class, hence .wid
@@ -112,7 +113,10 @@ class GooeyDataladCmdUI(QObject):
             # _get_datalad_param_spec() is our custom private adhoc method
             # expected to return a dict with a parameter setting, or an
             # empty dict, when the default shall be used.
-            params.update(field_widget.get_gooey_param_spec())
+            params.update({
+                k: v for k, v in field_widget.get_gooey_param_spec().items()
+                if v is not _NoValue
+            })
 
         # take a peek, TODO remove
         from pprint import pprint

--- a/datalad_gooey/tests/test_param_widget.py
+++ b/datalad_gooey/tests/test_param_widget.py
@@ -36,8 +36,8 @@ def test_GooeyParamWidgetMixin():
             pw_factory,
             name='peewee',
             docs='EXPLAIN!',
-            value=val,
             default=default,
         )
+        pw.set_gooey_param_value(val)
         # we get the set value back, not the default
         assert pw.get_gooey_param_spec() == {'peewee': val}


### PR DESCRIPTION
This changeset contains a range of significant updates

- Pre-setting a parameter value no longer disables the input widget. It merely sets the initial value.
- Parameter widgets (should) now emit a `value_changed` signal, whenever the value they would return on `get_gooey_param_spec()` would change.
- Parameter widget can now receive updates to other parameters via a init_gooey_from_other_param() slot. The default implementation does nothing, but particular widgets can use this to implement dynamic reconfiguration (set a new basedir for a filedialog when the reference dataset changes, etc)
- Parameters provide the `emit_gooey_value_changed()` method that can be used to connect "changed" signals of underlying input widget to, in order to emit standard `value_changed` signals with an attached parameter specification.
- The `allargs` specification and the corresponding `set_gooey_cmdkwargs()` method have been removed. They are fully replaced by the superior dynamic reconfiguration.
- Parameter widget creation no longer involves setting a specific value. Only a default is set, if provided. `set_gooey_param_value()` must be called explicitly now.
- `get_gooey_param_spec()` no longer returns an empty dict with an unchanged parameter value, but a dict with the parameter name mapped to `_NoValue`.

What is started here could be continued in order to enable more comprehensive dynamic form content updates. For example, we could "send" additions of values to a `path` parameter input widget directly from the tree view (needs #105 resolved first).