### PR TITLE
Send Tracebacks to dedicated Traceback tab to prevent clutter

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -47,8 +47,10 @@ class GooeyApp(QObject):
         'contextTabs': QTabWidget,
         'cmdTab': QWidget,
         'clearLogPB': QPushButton,
+        'clearTbPB': QPushButton,
         'fsBrowser': QTreeWidget,
         'logViewer': QPlainTextEdit,
+        'tbViewer': QPlainTextEdit,
         'menuDataset': QMenu,
         'menuView': QMenu,
         'menuUtilities': QMenu,
@@ -144,9 +146,9 @@ class GooeyApp(QObject):
             # if a command crashes, state it in the statusbar
             self.get_widget('statusbar').showMessage(f'`{cmdname}` failed')
             # but also barf the error into the logviewer
-            lv = self.get_widget('logViewer')
+            lv = self.get_widget('tbViewer')
             lv.appendHtml(
-                f'<font color="red">{ce.format_standard()}</font>'
+                f'<br><font color="red">{ce.format_standard()}</font>'
             )
         if not self._cmdexec.n_running:
             self.main_window.setCursor(QCursor(Qt.ArrowCursor))

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -158,6 +158,49 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="tab2">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;View Tracebacks of failed command executions&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <attribute name="title">
+         <string>Traceback</string>
+        </attribute>
+        <widget class="QPlainTextEdit" name="tbViewer">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>10</y>
+           <width>760</width>
+           <height>200</height>
+          </rect>
+         </property>
+         <property name="acceptDrops">
+          <bool>false</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;View tracebacks of failed commands&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="whatsThis">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Traceback Viewer for details on failures&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOn</enum>
+         </property>
+        </widget>
+        <widget class="QPushButton" name="clearTbPB">
+         <property name="geometry">
+          <rect>
+           <x>648</x>
+           <y>215</y>
+           <width>121</width>
+           <height>26</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Clear Traceback</string>
+         </property>
+        </widget>
+       </widget>
       </widget>
      </widget>
     </item>


### PR DESCRIPTION
Long tracebacks can completely fill the log/console tab, obscuring the command logs and custom rendering (see #141).
This change sends tracebacks to a dedicated 'traceback' tab.
![Screenshot from 2022-09-20 10-37-04](https://user-images.githubusercontent.com/29738718/191210067-81fc9a73-22c3-4a2c-925b-8a37af40d527.png)
![Screenshot from 2022-09-20 10-37-16](https://user-images.githubusercontent.com/29738718/191210089-93dde560-5eba-4c86-835e-fc0645a9ad37.png)
