### PR TITLE
Define parameter order in "complete" API based on command signature

### DIFF
--- a/datalad_gooey/api_utils.py
+++ b/datalad_gooey/api_utils.py
@@ -1,4 +1,12 @@
 
+from collections.abc import Callable
+from itertools import zip_longest
+from typing import List
+
+from datalad.utils import getargspec
+
+from .utils import _NoValue
+
 
 def get_cmd_displayname(api, cmdname):
     dname = api.get(cmdname, {}).get(
@@ -10,3 +18,24 @@ def get_cmd_displayname(api, cmdname):
         dname = f'Create a {" ".join(dname_parts[2:])}' \
                 f'{" " if len(dname_parts) > 2 else ""}sibling'
     return dname
+
+
+def get_cmd_params(cmd: Callable) -> List:
+    """Take a callable and return a list of parameter names, and their defaults
+
+    Parameter names and defaults are returned as 2-tuples. If a parameter has
+    no default, the special value `_NoValue` is used.
+    """
+    # lifted from setup_parser_for_interface()
+    args, varargs, varkw, defaults = getargspec(cmd, include_kwonlyargs=True)
+    return list(
+        zip_longest(
+            # fuse parameters from the back, to match with their respective
+            # defaults -- if soem have no defaults, they would be the first
+            args[::-1],
+            defaults[::-1],
+            # pad with a dedicate type, to be able to tell if there was a
+            # default or not
+            fillvalue=_NoValue)
+    # reverse the order again to match the original order in the signature
+    )[::-1]

--- a/datalad_gooey/api_utils.py
+++ b/datalad_gooey/api_utils.py
@@ -28,6 +28,8 @@ def get_cmd_params(cmd: Callable) -> List:
     """
     # lifted from setup_parser_for_interface()
     args, varargs, varkw, defaults = getargspec(cmd, include_kwonlyargs=True)
+    if not args:
+        return []
     return list(
         zip_longest(
             # fuse parameters from the back, to match with their respective

--- a/datalad_gooey/complete_api.py
+++ b/datalad_gooey/complete_api.py
@@ -57,6 +57,15 @@ for mname in dir(dlapi):
     cmd_group = _cmd_group_lookup.get(cls)
     if cmd_group:
         cmd_spec['group'] = cmd_group
+    # order of parameters is defined by order in the signature of the command
+    parameter_order = {p[0]: i for i, p in enumerate(get_cmd_params(m))}
+    # but always put any existing `dataset` parameter first, because (minus a
+    # few exceptions) it will define the scope of a command, and also influence
+    # other parameter choices (list of available remotes, basedir, etc.).
+    # therefore it is useful to have users process this first
+    if 'dataset' in parameter_order:
+        parameter_order['dataset'] = -1
+    cmd_spec['parameter_order'] = parameter_order
 
     api[mname] = cmd_spec
 

--- a/datalad_gooey/complete_api.py
+++ b/datalad_gooey/complete_api.py
@@ -9,7 +9,10 @@ from datalad.interface.base import (
 )
 from datalad.utils import get_wrapped_class
 
-from .api_utils import get_cmd_displayname
+from .api_utils import (
+    get_cmd_displayname,
+    get_cmd_params,
+)
 
 
 # mapping of command interface classes to interface group titles

--- a/datalad_gooey/param_multival_widget.py
+++ b/datalad_gooey/param_multival_widget.py
@@ -18,8 +18,8 @@ from datalad.utils import ensure_list
 from .param_widgets import (
     GooeyParamWidgetMixin,
     load_parameter_widget,
-    _NoValue,
 )
+from .utils import _NoValue
 
 
 class MyItemDelegate(QStyledItemDelegate):

--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -23,16 +23,7 @@ from PySide6.QtWidgets import (
 from datalad import cfg as dlcfg
 
 from .resource_provider import gooey_resources
-
-
-class _NoValue:
-    """Type to annotate the absence of a value
-
-    For example in a list of parameter defaults. In general `None` cannot
-    be used, as it may be an actual value, hence we use a local, private
-    type.
-    """
-    pass
+from .utils import _NoValue
 
 
 class GooeyParamWidgetMixin:

--- a/datalad_gooey/utils.py
+++ b/datalad_gooey/utils.py
@@ -1,9 +1,20 @@
 from pathlib import Path
+
 from PySide6.QtUiTools import QUiLoader
 from PySide6.QtCore import (
     QFile,
     QIODevice,
 )
+
+
+class _NoValue:
+    """Type to annotate the absence of a value
+
+    For example in a list of parameter defaults. In general `None` cannot
+    be used, as it may be an actual value, hence we use a local, private
+    type.
+    """
+    pass
 
 
 def load_ui(name, parent=None):


### PR DESCRIPTION
With the exception of the `dataset` argument, which is always sorted first.