### PR TITLE
UX: Use Python package name of dark theme dependency

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -249,7 +249,7 @@ class GooeyApp(QObject):
                 import qdarktheme
             except ImportError:
                 lgr.warning('Custom UI theme not supported. '
-                            'Missing `qdarktheme` installation.')
+                            'Missing `pyqtdarktheme` installation.')
                 return
             qtapp.setStyleSheet(qdarktheme.load_stylesheet(uitheme))
 


### PR DESCRIPTION
It tried out the dark theme, and wanted to follow the warnings advice of installing the 'missing qdarktheme installation'. However, pip install qdarktheme does not find a matching package, and I didn't find a different package manager that contained a package of this name. I suppose that the relevant Python package is called pyqtdarktheme, and I think its easier to find this out if the warning uses its package name