### PR TITLE
Fix defaults for parameter widgets

### DIFF
--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -278,6 +278,10 @@ class BoolParamWidget(QCheckBox, GooeyParamWidgetMixin):
         # convert to bool
         return state == Qt.Checked
 
+    def set_gooey_param_spec(self, name: str, default=_NoValue):
+        super().set_gooey_param_spec(name, default)
+        self._set_gooey_param_value(default)
+
 
 class StrParamWidget(QLineEdit, GooeyParamWidgetMixin):
     def _set_gooey_param_value(self, value):

--- a/datalad_gooey/tests/test_dataladcmd_ui.py
+++ b/datalad_gooey/tests/test_dataladcmd_ui.py
@@ -36,7 +36,8 @@ def test_GooeyDataladCmdUI(gooey_app, *, qtbot):
         qtbot.mouseClick(ok_button, Qt.LeftButton)
 
     assert_equal(blocker.args[0], 'wtf')
-    assert_in("decor", blocker.args[1].keys())
+    # no parameters given, means none passed via signal:
+    assert_equal({}, blocker.args[1])
 
     # reset_form
     cmdui.reset_form()

--- a/datalad_gooey/tests/test_param_widget.py
+++ b/datalad_gooey/tests/test_param_widget.py
@@ -1,6 +1,8 @@
 import functools
 from pathlib import Path
 
+from PySide6.QtWidgets import QWidget
+
 from ..param_widgets import (
     BoolParamWidget,
     StrParamWidget,
@@ -28,24 +30,27 @@ def test_GooeyParamWidgetMixin():
             (PathParamWidget, str(Path.cwd()), None),
             # cannot include MultiValueInputWidget, leads to Python segfault
             # on garbage collection?!
-            # (functools.partial(
-            #     MultiValueInputWidget, PathParamWidget),
-            #  [str(Path.cwd()), 'temp'],
-            #  'mypath'),
-            # (functools.partial(
-            #     MultiValueInputWidget, PathParamWidget),
-            #  [str(Path.cwd()), 'temp'],
-            #  None),
+            (functools.partial(
+                MultiValueInputWidget, PathParamWidget),
+             [str(Path.cwd()), 'temp'],
+             'mypath'),
+            (functools.partial(
+                MultiValueInputWidget, PathParamWidget),
+             [str(Path.cwd()), 'temp'],
+             None),
 
     ):
         # this is how all parameter widgets are instantiated
+        parent = QWidget()  # we need parent to stick around,
+                            # so nothing gets picked up by GC
         pw = load_parameter_widget(
-            None,
+            parent,
             pw_factory,
             name='peewee',
             docs='EXPLAIN!',
             default=default,
         )
+
         # If nothing was set yet, we expect `_NoValue` as the "representation of
         # default" here:
         assert pw.get_gooey_param_spec() == {'peewee': _NoValue}, \

--- a/datalad_gooey/tests/test_param_widget.py
+++ b/datalad_gooey/tests/test_param_widget.py
@@ -10,7 +10,7 @@ from ..param_widgets import (
     load_parameter_widget,
 )
 from ..param_multival_widget import MultiValueInputWidget
-
+from ..utils import _NoValue
 
 
 def test_GooeyParamWidgetMixin():
@@ -18,17 +18,25 @@ def test_GooeyParamWidgetMixin():
     # through the GooeyParamWidgetMixin API
 
     for pw_factory, val, default in (
-            (BoolParamWidget, True, False),
+            (BoolParamWidget, False, True),
+            (BoolParamWidget, False, None),
             (PosIntParamWidget, 4, 1),
+            (functools.partial(PosIntParamWidget, True), 4, None),
             (StrParamWidget, 'dummy', 'mydefault'),
             (functools.partial(ChoiceParamWidget, ['a', 'b', 'c']), 'b', 'c'),
             (PathParamWidget, str(Path.cwd()), 'mypath'),
+            (PathParamWidget, str(Path.cwd()), None),
             # cannot include MultiValueInputWidget, leads to Python segfault
             # on garbage collection?!
-            #(functools.partial(
-            #    MultiValueInputWidget, PathParamWidget),
-            # [str(Path.cwd()), 'temp'],
-            # 'mypath'),
+            # (functools.partial(
+            #     MultiValueInputWidget, PathParamWidget),
+            #  [str(Path.cwd()), 'temp'],
+            #  'mypath'),
+            # (functools.partial(
+            #     MultiValueInputWidget, PathParamWidget),
+            #  [str(Path.cwd()), 'temp'],
+            #  None),
+
     ):
         # this is how all parameter widgets are instantiated
         pw = load_parameter_widget(
@@ -38,6 +46,10 @@ def test_GooeyParamWidgetMixin():
             docs='EXPLAIN!',
             default=default,
         )
+        # If nothing was set yet, we expect `_NoValue` as the "representation of
+        # default" here:
+        assert pw.get_gooey_param_spec() == {'peewee': _NoValue}, \
+            f"Default value not retrieved from {pw_factory.__class__}"
         pw.set_gooey_param_value(val)
         # we get the set value back, not the default
         assert pw.get_gooey_param_spec() == {'peewee': val}


### PR DESCRIPTION
This adds a test for parameter widgets to deliver a representation of the default value (currently `_NoValue`) after initialization with the parameter specification and consequently fixes several classes that failed this test, delivering the native default of the respective Qt widget instead.
It also fixes the Mixin implementation of `get_gooey_param_spec` to deliver the same representation of default under all conditions.

Alternatively, `ChoiceParamWidget` and `PosIntParamWidget` could implement an equivalent of the `StrParamWidget`'s `setModified` approach by wiring up the respective signals, but this simpler approach of just setting the default as the current value also serves the purpose of a visual representation of the default for those widget types. I don't see a case where this approach would fail. Do you agree, @mih?


Closes #179
(but not yet  #181, which is a special case)