### PR TITLE
Simplistic (enforced) ASKPASS helper

### DIFF
--- a/datalad_gooey/__init__.py
+++ b/datalad_gooey/__init__.py
@@ -13,6 +13,8 @@ command_suite = (
     "Gooey (GUI)",
     [
         ('datalad_gooey.gooey', 'Gooey'),
+        ('datalad_gooey.askpass', 'GooeyAskPass',
+         'gooey-askpass', 'gooey_askpass'),
         ('datalad_gooey.lsdir', 'GooeyLsDir', 'gooey-lsdir', 'gooey_lsdir'),
         ('datalad_gooey.status_light', 'GooeyStatusLight',
          'gooey-status-light', 'gooey_status_light'),

--- a/datalad_gooey/askpass.py
+++ b/datalad_gooey/askpass.py
@@ -1,0 +1,35 @@
+"""DataLad GUI password entry helper"""
+
+__docformat__ = 'restructuredtext'
+
+import logging
+import sys
+
+from datalad.interface.base import Interface
+from datalad.interface.base import build_doc
+
+
+lgr = logging.getLogger('datalad.ext.gooey.askpass')
+
+
+@build_doc
+class GooeyAskPass(Interface):
+    """Internal helper for datalad-gooey"""
+
+    @staticmethod
+    def __call__():
+        # internal import to keep unconditional dependencies low
+        from PySide6.QtWidgets import (
+            QApplication,
+            QInputDialog,
+        )
+
+        QApplication(sys.argv)
+        cred, ok = QInputDialog.getText(
+            None,
+            'DataLad Gooey',
+            sys.argv[1],
+        )
+        if not ok:
+            sys.exit(2)
+        sys.stdout.write(cred)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ High-level API commands
    :toctree: generated
 
    gooey
+   gooey_askpass
    gooey_lsdir
    gooey_status_light
 
@@ -27,6 +28,7 @@ Command line reference
    :maxdepth: 1
 
    generated/man/datalad-gooey
+   generated/man/datalad-gooey-askpass
    generated/man/datalad-gooey-lsdir
    generated/man/datalad-gooey-status-light
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,10 @@ datalad.extensions =
     gooey = datalad_gooey:command_suite
 # install the GUI starter as a direct entrypoint to avoid the datalad CLI
 # overhead
-gui_scripts = datalad-gooey = datalad_gooey.app:main
+gui_scripts =
+    datalad-gooey = datalad_gooey.app:main
+console_scripts =
+    datalad-gooey-askpass = datalad_gooey.askpass:GooeyAskPass.__call__
 
 [versioneer]
 # See the docstring in versioneer.py for instructions. Note that you must


### PR DESCRIPTION
The new `gooey-askpass` command implements the traditional SSH_ASKPASS API. It opens a simple input dialog with the given prompt, collects input, and writes it to `stdout`.

Within Gooey this helper is not the enforced method for anything that honors a normal SSH_ASKPASS setup -- this includes Git and SSH.

So any such requests should now show up in the GUI, rather than be hidden in the terminal.

Closes datalad/datalad-gooey#177