### PR TITLE
Recognize annexed-files in browser, support dedicated actions

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -416,11 +416,14 @@ class GooeyFilesystemBrowser(QObject):
             else:
                 from .active_api import directory_api as cmdapi
             submenu = context.addMenu('Directory commands')
-        elif path_type in ('file', 'symlink'):
+        elif path_type in ('file', 'symlink', 'annexed-file'):
             dsroot = get_dataset_root(ipath)
             cmdkwargs['path'] = ipath
             if dsroot:
-                from .active_api import file_in_ds_api as cmdapi
+                if path_type == 'annexed-file':
+                    from .active_api import annexed_file_api as cmdapi
+                else:
+                    from .active_api import file_in_ds_api as cmdapi
                 cmdkwargs['dataset'] = dsroot
             else:
                 from .active_api import file_api as cmdapi

--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -116,6 +116,8 @@ class FSBrowserItem(QTreeWidgetItem):
                 type_icon = 'file-git'
                 if res.get('key'):
                     type_icon = 'file-annex'
+                    # disambiguate from a file in Git
+                    type_ = 'annexed-file'
             self.set_item_type(type_, icon=type_icon)
 
     def update_from_lsdir_result(self, res: Dict):

--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -62,7 +62,7 @@ api = dict(
         name='Create a &WebDAV sibling',
     ),
     drop=dict(
-        name='Dr&op dataset content',
+        name='Dr&op content',
         exclude_parameters=set((
             'check',
             'if_dirty',
@@ -70,7 +70,7 @@ api = dict(
         )),
     ),
     get=dict(
-        name='&Get dataset content',
+        name='&Get content',
         exclude_parameters=set((
             'description',
             'reckless',
@@ -157,7 +157,7 @@ directory_in_ds_api = {
 }
 file_api = None
 file_in_ds_api = {
-    c: s for c, s in api.items() if c in ('save', 'get', 'drop')
+    c: s for c, s in api.items() if c in ('save')
 }
 annexed_file_api = {
     c: s for c, s in api.items()


### PR DESCRIPTION
It makes sense to visually distinguish annexed files from files in Git. Here this is done via a dedicated type label `annexed-file`.

This logical separation enables supporting `annexed_file_api` actions for any such files, and only those.

So annexed files offer `get/drop`, but files in Git not.

Closes datalad/datalad-gooey#188

![image](https://user-images.githubusercontent.com/136479/191733567-baced73b-43b4-4158-abe3-73410cb21345.png)
