### PR TITLE
New `EnsureExistingDirectory` parameter constraint

### DIFF
--- a/datalad_gooey/constraints.py
+++ b/datalad_gooey/constraints.py
@@ -1,5 +1,9 @@
+from pathlib import Path
 
-from datalad.support.constraints import EnsureStr
+from datalad.support.constraints import (
+    Constraint,
+    EnsureStr,
+)
 
 
 class EnsureDatasetSiblingName(EnsureStr):
@@ -19,3 +23,11 @@ class EnsureDatasetSiblingName(EnsureStr):
 
     def short_description(self):
         return 'sibling name'
+
+
+class EnsureExistingDirectory(Constraint):
+    def __call__(self, value):
+        if not Path(value).is_dir():
+            raise ValueError(
+                f"{value} is not an existing directory")
+        return value

--- a/datalad_gooey/param_form_utils.py
+++ b/datalad_gooey/param_form_utils.py
@@ -33,7 +33,10 @@ from .active_api import (
 )
 from .api_utils import get_cmd_params
 from .utils import _NoValue
-from .constraints import EnsureDatasetSiblingName
+from .constraints import (
+    EnsureExistingDirectory,
+    EnsureDatasetSiblingName,
+)
 
 __all__ = ['populate_form_w_params']
 
@@ -190,8 +193,8 @@ def _get_parameter_widget_factory(
 
     # if we have no idea, use a simple line edit
     type_widget = pw.StrParamWidget
-    # no some parameters where we can derive semantics from their name
-    if name == 'dataset':
+    # now some parameters where we can derive semantics from their name
+    if name == 'dataset' or isinstance(constraints, EnsureExistingDirectory):
         type_widget = functools.partial(
             pw.PathParamWidget,
             pathtype=QFileDialog.Directory,
@@ -201,6 +204,8 @@ def _get_parameter_widget_factory(
             pw.PathParamWidget, basedir=basedir)
     elif name == 'cfg_proc':
         type_widget = pw.CfgProcParamWidget
+    elif name == 'recursion_limit':
+        type_widget = functools.partial(pw.PosIntParamWidget, allow_none=True)
     # now parameters where we make decisions based on their configuration
     elif isinstance(constraints, EnsureDatasetSiblingName):
         type_widget = pw.SiblingChoiceParamWidget
@@ -212,8 +217,6 @@ def _get_parameter_widget_factory(
     elif argparse_spec.get('choices'):
         type_widget = functools.partial(
             pw.ChoiceParamWidget, choices=argparse_spec.get('choices'))
-    elif name == 'recursion_limit':
-        type_widget = functools.partial(pw.PosIntParamWidget, allow_none=True)
 
     # we must consider the following nargs spec for widget selection
     # (int, '*', '+'), plus action=append

--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -1,4 +1,7 @@
-from .constraints import EnsureDatasetSiblingName
+from .constraints import (
+    EnsureDatasetSiblingName,
+    EnsureExistingDirectory,
+)
 
 # each item is a command that is allowed in the API
 # the key is the command name in the Python API.
@@ -24,6 +27,9 @@ api = dict(
             path=1,
             dataset=2,
         ),
+        parameter_constraints=dict(
+            path=EnsureExistingDirectory(),
+        ),
     ),
     create=dict(
         name='C&reate a dataset',
@@ -41,6 +47,9 @@ api = dict(
             path=0,
             annex=1,
             dataset=2,
+        ),
+        parameter_constraints=dict(
+            path=EnsureExistingDirectory(),
         ),
     ),
     create_sibling_gitlab=dict(


### PR DESCRIPTION
It is now used for the `path` parameters of `clone` and `create`.

This implies that users can not longer specific non-existing locations as targets for these operations. However, this ability has already been reported as confusing: https://github.com/datalad/datalad-gooey/issues/144

Closes datalad/datalad-gooey#153