### PR TITLE
Add a very basic help tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -1,0 +1,56 @@
+name: Gooey issue
+
+# For documentation concerning the Github form schema see
+# https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema
+
+description: Gooey issue
+
+body:
+  - type: textarea
+    attributes:
+      label: What is the problem?
+      description: "Please summarize the issue briefly. Add screenshots if they 
+      help to illustrate it, or copy-paste error messages"
+      placeholder: "Example: The App is unresponsive when I click on Help"
+
+  - type: textarea
+    attributes:
+      label: What steps will reproduce the problem?
+      description: "How do you trigger this bug? Please walk us through it step
+       by step."
+      placeholder: "Example: Open the App from the Desktop shortcut. Select 
+      Documents as the root folder. Click the Help Tab. Boom"
+      value: |
+        1.
+        2. 
+        3.
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: "Is there anything else that would be useful to know in this 
+      context? Please also copy-paste relevant output from the Command log, 
+      Error log, or the background Terminal."
+
+  - type: checkboxes
+    id: installer
+    attributes:
+      label: How did you install the App?
+      options:
+        - label: Via the Windows installer
+        - label: Using pip (``pip install datalad-gooey``)
+        - label: Using brew (``brew install datalad-gooey``)
+        - label: Using conda (``conda install -c forge datalad-gooey``)
+        - label: Not sure
+        - label: Other
+
+  - type: textarea
+    attributes:
+      label: System information
+      description: |
+        Please tell us more about your system, including operating system and
+        software versions. The more information we get, the better. You can
+        copy-paste this information from 'Help' -> 'Diagnostic infos' 

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -270,25 +270,18 @@ class GooeyApp(QObject):
     def _get_issue_template(self):
         mbox = QMessageBox.warning
         title = 'Oooops'
-        msg = 'If you see something unexpected or faulty, please report it ' \
-              'to us: <ul>' \
-              '<li>Something is wrong with this Gooey? <br>' \
-              '<a href=https://github.com/datalad/datalad-gooey/issues/new?assignees=&labels=&template=issue_template.yml>' \
-              'File a report at datalad-gooey </a> </li>' \
-              '<li>Something is wrong with DataLad? <br>' \
-              '<a href=https://github.com/datalad/datalad-gooey/issues/new?assignees=&labels=&template=issue_template.yml>' \
-              'File a report at DataLad</a></ul> <br>'
+        msg = 'Please report unexpected or faulty behavior to us. File a ' \
+              'report with <a href=https://github.com/datalad/datalad-gooey/issues/new?assignees=&labels=&template=issue_template.yml>' \
+              'datalad-gooey </a> or with <a href=https://github.com/datalad/datalad-gooey/issues/new?assignees=&labels=&template=issue_template.yml>' \
+              'DataLad</a>'
         mbox(self.main_window, title, msg)
 
     def _get_help(self):
         mbox = QMessageBox.information
         title = 'I need help!'
-        msg = 'You can resources to learn more or ask questions here: <ul>' \
-              '<li>More information on DataLad Gooey: ' \
-              '<a href=docs.datalad.org> add me </a> </li>' \
-              '<li>General DataLad user tutorials:' \
-              '<a href=http://handbook.datalad.org> handbook.datalad.org </a>' \
-              '</li>' \
+        msg = 'Find resources to learn more or ask questions here: <ul><li>' \
+              'About this tool:<a href=http://docs.datalad.org/projects/gooey/en/latest>DataLad Gooey Docs</a> </li>' \
+              '<li>General DataLad user tutorials: <a href=http://handbook.datalad.org> handbook.datalad.org </a> </li>' \
               '<li>Live chat and weekly office hour: <a href=https://matrix.to/#/!NaMjKIhMXhSicFdxAj:matrix.org?via=matrix.waite.eu&via=matrix.org&via=inm7.de>' \
               'Join us on Matrix </li></ul>'
         mbox(self.main_window, title, msg)
@@ -296,10 +289,10 @@ class GooeyApp(QObject):
     def _get_info(self):
         mbox = QMessageBox.information
         title = 'About'
-        msg = 'DataLad development is supported primarily by the US ' \
-              'National Science Foundation and the German Federal ' \
-              'Ministry of Education and Research. Find out more at ' \
-              '<a href=http://datalad.org>datalad.org </a>'
+        msg = 'DataLad and DataLad Gooey are free and open source software. ' \
+              'Read the <a href=https://doi.org/10.21105/joss.03262> paper' \
+              '</a>, or find out more at <a href=http://datalad.org>' \
+              'datalad.org</a>.'
         mbox(self.main_window, title, msg)
 
     def _connect_menu_view(self, menu: QMenu):

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -56,10 +56,14 @@ class GooeyApp(QObject):
         'commandLog': QPlainTextEdit,
         'errorLog': QPlainTextEdit,
         'menuDataset': QMenu,
+        'menuHelp': QMenu,
         'menuView': QMenu,
         'menuUtilities': QMenu,
         'statusbar': QStatusBar,
         'actionCheck_for_new_version': QAction,
+        'actionReport_a_problem': QAction,
+        'actionAbout': QAction,
+        'actionGetHelp': QAction
     }
 
     execute_dataladcmd = Signal(str, MappingProxyType, MappingProxyType)
@@ -134,6 +138,12 @@ class GooeyApp(QObject):
             self._populate_dataset_menu)
         self.main_window.actionCheck_for_new_version.triggered.connect(
             self._check_new_version)
+        self.main_window.actionReport_a_problem.triggered.connect(
+            self._get_issue_template)
+        self.main_window.actionGetHelp.triggered.connect(
+            self._get_help)
+        self.main_window.actionAbout.triggered.connect(
+            self._get_info)
         # reset the command configuration tab whenever the item selection in
         # tree view changed.
         # This behavior was originally requested in
@@ -255,6 +265,41 @@ class GooeyApp(QObject):
             mbox = QMessageBox.warning
             msg = f'A newer DataLad version {latest} ' \
                   f'is available (installed: {dlversion}).'
+        mbox(self.main_window, title, msg)
+
+    def _get_issue_template(self):
+        mbox = QMessageBox.warning
+        title = 'Oooops'
+        msg = 'If you see something unexpected or faulty, please report it ' \
+              'to us: <ul>' \
+              '<li>Something is wrong with this Gooey? <br>' \
+              '<a href=https://github.com/datalad/datalad-gooey/issues/new?assignees=&labels=&template=issue_template.yml>' \
+              'File a report at datalad-gooey </a> </li>' \
+              '<li>Something is wrong with DataLad? <br>' \
+              '<a href=https://github.com/datalad/datalad-gooey/issues/new?assignees=&labels=&template=issue_template.yml>' \
+              'File a report at DataLad</a></ul> <br>'
+        mbox(self.main_window, title, msg)
+
+    def _get_help(self):
+        mbox = QMessageBox.information
+        title = 'I need help!'
+        msg = 'You can resources to learn more or ask questions here: <ul>' \
+              '<li>More information on DataLad Gooey: ' \
+              '<a href=docs.datalad.org> add me </a> </li>' \
+              '<li>General DataLad user tutorials:' \
+              '<a href=http://handbook.datalad.org> handbook.datalad.org </a>' \
+              '</li>' \
+              '<li>Live chat and weekly office hour: <a href=https://matrix.to/#/!NaMjKIhMXhSicFdxAj:matrix.org?via=matrix.waite.eu&via=matrix.org&via=inm7.de>' \
+              'Join us on Matrix </li></ul>'
+        mbox(self.main_window, title, msg)
+
+    def _get_info(self):
+        mbox = QMessageBox.information
+        title = 'About'
+        msg = 'DataLad development is supported primarily by the US ' \
+              'National Science Foundation and the German Federal ' \
+              'Ministry of Education and Research. Find out more at ' \
+              '<a href=http://datalad.org>datalad.org </a>'
         mbox(self.main_window, title, msg)
 
     def _connect_menu_view(self, menu: QMenu):

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -94,7 +94,7 @@
                <x>0</x>
                <y>0</y>
                <width>381</width>
-               <height>152</height>
+               <height>142</height>
               </rect>
              </property>
             </widget>
@@ -211,7 +211,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>21</height>
+     <height>23</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuUtilities">
@@ -253,10 +253,19 @@
     <addaction name="menuInterface"/>
     <addaction name="menuTheme"/>
    </widget>
+   <widget class="QMenu" name="menuHelp">
+    <property name="title">
+     <string>Help</string>
+    </property>
+    <addaction name="actionReport_a_problem"/>
+    <addaction name="actionAbout"/>
+    <addaction name="actionGetHelp"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDataset"/>
    <addaction name="menuView"/>
    <addaction name="menuUtilities"/>
+   <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <action name="actionCheck_for_new_version">
@@ -305,6 +314,21 @@
   <action name="actionViewTheme_dark">
    <property name="text">
     <string>Dark</string>
+   </property>
+  </action>
+  <action name="actionReport_a_problem">
+   <property name="text">
+    <string>Report a problem</string>
+   </property>
+  </action>
+  <action name="actionAbout">
+   <property name="text">
+    <string>About</string>
+   </property>
+  </action>
+  <action name="actionGetHelp">
+   <property name="text">
+    <string>Get help</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Not very pretty, but a start:

- [x] TODO: create custom issue templates for gooey users at the datalad and datalad-gooey repositories and link them properly. Those templates can query for Gooey relevant details, such as Window manager or Gooey version.

![image](https://user-images.githubusercontent.com/29738718/191803679-5ed9d233-5cdc-402a-ad4f-5e2e1a7a30e9.png)
