### PR TITLE
Add diagnostic infos helper to help tag

### DIFF
--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -260,6 +260,7 @@
     <addaction name="actionReport_a_problem"/>
     <addaction name="actionAbout"/>
     <addaction name="actionGetHelp"/>
+    <addaction name="actionDiagnostic_infos"/>
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuDataset"/>
@@ -329,6 +330,11 @@
   <action name="actionGetHelp">
    <property name="text">
     <string>Get help</string>
+   </property>
+  </action>
+  <action name="actionDiagnostic_infos">
+   <property name="text">
+    <string>Diagnostic infos</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Clicking it triggers an internal WTF call, of which the output is automatically enclosed in HTML details tags and markdowns code markup, and copied to the Clipboard. User can then paste it into GitHub issues.

Closes #201