### PR TITLE
Minimal progress reporting in the status bar

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -130,7 +130,8 @@ class GooeyApp(QObject):
         # looks silly with the uiuiuiuiui, but these are the real names ;-)
         dlui.KNOWN_BACKENDS['gooey'] = GooeyUI
         dlui.ui.set_backend('gooey')
-        dlui.ui.ui.set_app(self)
+        uibridge = dlui.ui.ui.set_app(self)
+        self.get_widget('statusbar').addPermanentWidget(uibridge.progress_bar)
 
         # connect the generic cmd execution signal to the handler
         self.execute_dataladcmd.connect(self._cmdexec.execute)


### PR DESCRIPTION
This is not the epic implementation of datalad core, no units, no 12 progress bars.

There is one progress bar whenever there is any progress reporting ongoing.

If there is more than one process reporting progress at a time, the "average progress" is reported. This makes the progress a bit jumpy.

If a particular progress tracker does not have a known total value (aspirational goal), it is presently ignored. However, the Qt widget allows for "busy indicator" mode. So this could be supported top.

Closes datalad/datalad-gooey#156

https://user-images.githubusercontent.com/136479/191959749-087f2fd3-05ef-4fe0-8264-668927ad60c6.mp4


