### PR TITLE
Allow reckless for drop

### DIFF
--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -132,7 +132,7 @@ api = dict(
             what='What to drop',
             path='Only drop',
             recursive='Also drop (in) any subdatasets',
-            reckless='Disable safeguard(s)',
+            reckless='Disable safeguards',
         ),
         parameter_order=dict(
             dataset=0,

--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -126,19 +126,20 @@ api = dict(
         exclude_parameters=set((
             'check',
             'if_dirty',
-            'reckless',
         )),
         parameter_display_names=dict(
             dataset='Drop from dataset at',
             what='What to drop',
             path='Only drop',
             recursive='Also drop (in) any subdatasets',
+            reckless='Disable safeguard(s)',
         ),
         parameter_order=dict(
             dataset=0,
             what=1,
             path=2,
             recursive=3,
+            reckless=4,
         ),
     ),
     get=dict(


### PR DESCRIPTION
Enhance drop's command config tab with an option to set the `reckless` parameter. This is needed for drop, since otherwise users can't wipe out local datasets w/o no siblings (that may have been created for testing or by accident).