### PR TITLE
Manually adjust choice widget

### DIFF
--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -196,6 +196,18 @@ class ChoiceParamWidget(QComboBox, GooeyParamWidgetMixin):
             self.setPlaceholderText('No known choices')
             self.setDisabled(True)
         self.currentIndexChanged.connect(self._handle_input)
+        self._adjust_width()
+
+    def _adjust_width(self, max_chars=80, margin_chars=3):
+        if not self.count():
+            return
+        self.setMinimumContentsLength(
+            min(
+                max_chars,
+                max(len(self.itemText(r))
+                    for r in range(self.count())) + margin_chars
+            )
+        )
 
     def _set_gooey_param_value_in_widget(self, value):
         self.setCurrentText(self._gooey_map_val2label(value))


### PR DESCRIPTION
On a mac it was clipping of the last 3 chars. Now we do 3 chars more than the max length of any item, unless exceeding 80 chars.

Subclasses can call this method too, and also use other parameters.

Closes #229