### PR TITLE
Multiline text edit widget for message param

### DIFF
--- a/datalad_gooey/param_form_utils.py
+++ b/datalad_gooey/param_form_utils.py
@@ -239,6 +239,8 @@ def _get_parameter_widget_factory(
         type_widget = pw.CredentialChoiceParamWidget
     elif name == 'recursion_limit':
         type_widget = functools.partial(pw.PosIntParamWidget, allow_none=True)
+    elif name == 'message':
+        type_widget = pw.TextParamWidget
     # now parameters where we make decisions based on their configuration
     elif isinstance(constraints, EnsureDatasetSiblingName):
         type_widget = pw.SiblingChoiceParamWidget

--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLineEdit,
     QSpinBox,
+    QTextEdit,
     QToolButton,
     QWidget,
     QMessageBox,
@@ -304,6 +305,26 @@ class StrParamWidget(QLineEdit, GooeyParamWidgetMixin):
         self._set_gooey_param_value(self.text())
 
 
+class TextParamWidget(QTextEdit, GooeyParamWidgetMixin):
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptRichText(False)  # TODO: Could be an option
+        self.setAcceptDrops(True)
+        self.setPlaceholderText('Not set')
+        self.textChanged.connect(self._handle_input)
+
+    def _set_gooey_param_value_in_widget(self, value):
+        if value in (_NoValue, None):
+            # we treat both as "unset"
+            self.clear()
+        else:
+            self.setText(str(value))
+
+    def _handle_input(self):
+        self._set_gooey_param_value(self.toPlainText())
+
+
 class PathParamWidget(QWidget, GooeyParamWidgetMixin):
     def __init__(self, basedir=None,
                  pathtype: QFileDialog.FileMode = QFileDialog.AnyFile,
@@ -447,6 +468,7 @@ class PathParamWidget(QWidget, GooeyParamWidgetMixin):
                 self._handle_drop(file)
         else:
             event.ignore()
+
 
 class CfgProcParamWidget(ChoiceParamWidget):
     """Choice widget with items from `run_procedure(discover=True)`"""


### PR DESCRIPTION
Provide a TextEdit widget and associate it with the `message` parameter. This widget allows for drag&drop. Furthermore, disabled RichText/HTML for now to keep it simple until this is better tested.

Closes #93