### PR TITLE
Docs: add description of supported functionality

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,7 +88,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Datalad Extension Template'
+project = u'Datalad Gooey'
 copyright = u'2018-{}, DataLad team'.format(datetime.datetime.now().year)
 author = u'DataLad team'
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,16 @@
-DataLad extension template
-**************************
+Welcome to DataLad Gooey's documentation!
+*****************************************
 
-This is a template for creating a `DataLad <http://datalad.org>`__ extension
-that equips DataLad with additional functionality.
+DataLad Gooey is a GUI application for using `DataLad`_. Currently the following
+DataLad functionality is supported:
+
+* `clone`_ a dataset
+* `create`_ a dataset
+* create a sibling (`GitLab`_, `GIN`_, `GitHub`_, `WebDAV`_)
+* `drop`_/`get`_ content
+* `push`_ data/updates to a sibling
+* `save`_ the state of a dataset
+* `update`_ from a sibling
 
 Overview
 ========
@@ -49,3 +57,16 @@ Indices and tables
 * :ref:`search`
 
 .. |---| unicode:: U+02014 .. em dash
+
+.. _DataLad: https://www.datalad.org/
+.. _clone: http://docs.datalad.org/en/stable/generated/man/datalad-clone.html
+.. _create: http://docs.datalad.org/en/stable/generated/man/datalad-create.html
+.. _GitLab: http://docs.datalad.org/en/stable/generated/man/datalad-create-sibling-gitlab.html
+.. _GIN: http://docs.datalad.org/en/stable/generated/man/datalad-create-sibling-gin.html
+.. _GitHub: http://docs.datalad.org/en/stable/generated/man/datalad-create-sibling-github.html
+.. _WebDAV: http://docs.datalad.org/projects/next/en/latest/generated/man/datalad-create-sibling-webdav.html
+.. _drop: http://docs.datalad.org/en/stable/generated/man/datalad-drop.html
+.. _get: http://docs.datalad.org/en/stable/generated/man/datalad-get.html
+.. _push: http://docs.datalad.org/en/stable/generated/man/datalad-push.html
+.. _save: http://docs.datalad.org/en/stable/generated/man/datalad-save.html
+.. _update: http://docs.datalad.org/en/stable/generated/man/datalad-update.html


### PR DESCRIPTION
Includes links to the datalad docs for the supported commands.

Towards #45 