### PR TITLE
Dump status annex=basic to property tab

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -403,8 +403,8 @@ class GooeyFilesystemBrowser(QObject):
         ipath = item.pathobj
         pbrowser.clear()
 
+        dsroot = get_dataset_root(ipath)
         if itype in ('file', 'annexed-file'):
-            dsroot = get_dataset_root(ipath)
             if dsroot is None:
                 # untracked file, we don't know anything
                 pbrowser.setText(f'Untracked file {ipath}')
@@ -421,7 +421,17 @@ class GooeyFilesystemBrowser(QObject):
                 text += "</table>"
                 pbrowser.setText(text)
         else:
-            pbrowser.setText(f'No information on {ipath}')
+            if dsroot is not None:
+                # TODO: consider `wtf -S dataset` as well - at least get the ID
+                dsrepo = Dataset(dsroot).repo
+                if hasattr(dsrepo, 'call_annex'):
+                    text = Dataset(dsroot).repo.call_annex(['info', '--fast'])
+                    pbrowser.setText(text)
+                else:
+                    pbrowser.setText(f'Git repository {ipath}')
+            else:
+                pbrowser.setText(f'No information on {ipath}')
+
 
     def _custom_context_menu(self, onpoint):
         """Present a context menu for the item click in the directory browser


### PR DESCRIPTION
For now, simply dump the output of `status --annex=basic` to a file's property tab (if it's part of a dataset. Similarly, just dump `annex info --fast` for a dataset.

Ping #193

![image](https://user-images.githubusercontent.com/10498301/192556461-2eada7d4-4245-4e66-a0e4-5db722d75b7d.png)

![image](https://user-images.githubusercontent.com/10498301/192559273-dd42b0b3-7eb4-4f49-b8df-024f8e20b820.png)

