### PR TITLE
Format parameter docs properly

### DIFF
--- a/datalad_gooey/api_utils.py
+++ b/datalad_gooey/api_utils.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from itertools import zip_longest
 from typing import List
 
+from datalad.interface.base import alter_interface_docs_for_api
 from datalad.utils import getargspec
 
 from .utils import _NoValue
@@ -41,3 +42,10 @@ def get_cmd_params(cmd: Callable) -> List:
             fillvalue=_NoValue)
     # reverse the order again to match the original order in the signature
     )[::-1]
+
+
+def format_param_docs(docs: str) -> str:
+    """Removes Python API formating of Parameter docs for GUI use"""
+    if not docs:
+        return docs
+    return alter_interface_docs_for_api(docs)

--- a/datalad_gooey/param_form_utils.py
+++ b/datalad_gooey/param_form_utils.py
@@ -26,7 +26,10 @@ from datalad.utils import (
 from . import param_widgets as pw
 from .param_multival_widget import MultiValueInputWidget
 from .active_suite import spec as active_suite
-from .api_utils import get_cmd_params
+from .api_utils import (
+    get_cmd_params,
+    format_param_docs,
+)
 from .utils import _NoValue
 from .constraints import (
     Constraint,
@@ -125,7 +128,7 @@ def populate_form_w_params(
             nargs=_get_nargs(pname, param_spec.cmd_kwargs),
             # will also be _NoValue, if there was none
             default=pdefault,
-            docs=param_spec._doc,
+            docs=format_param_docs(param_spec._doc),
             # TODO make obsolete
             argparse_spec=param_spec.cmd_kwargs,
         )


### PR DESCRIPTION
So far we included them "raw" including format macros.

For now we apply the formatting style of the Python API.

Ping https://github.com/datalad/datalad-gooey/issues/265

More will be possible when https://github.com/datalad/datalad/issues/7062 is addressed.