### PR TITLE
Add a "Help" tab and display the command help in it

### DIFF
--- a/datalad_gooey/api_utils.py
+++ b/datalad_gooey/api_utils.py
@@ -49,3 +49,10 @@ def format_param_docs(docs: str) -> str:
     if not docs:
         return docs
     return alter_interface_docs_for_api(docs)
+
+
+def format_cmd_docs(docs: str) -> str:
+    """Removes Python API formating of Interface docs for GUI use"""
+    if not docs:
+        return docs
+    return alter_interface_docs_for_api(docs)

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -28,6 +28,7 @@ from PySide6.QtGui import (
     QGuiApplication,
 )
 
+import datalad
 from datalad import cfg as dlcfg
 from datalad import __version__ as dlversion
 import datalad.ui as dlui
@@ -59,6 +60,7 @@ class GooeyApp(QObject):
     _main_window_widgets = {
         'contextTabs': QTabWidget,
         'cmdTab': QWidget,
+        'helpBrowser': QTextBrowser,
         'propertyBrowser': QTextBrowser,
         'fsBrowser': QTreeWidget,
         'commandLog': QPlainTextEdit,
@@ -82,6 +84,9 @@ class GooeyApp(QObject):
     def __init__(self, path: Path = None):
         super().__init__()
         # bend datalad to our needs
+        # e.g. prevent doc assembly for Python API -- we are better off with
+        # the raw material
+        datalad.enable_librarymode()
         # we cannot handle ANSI coloring
         dlcfg.set('datalad.ui.color', 'off', scope='override', force=True)
 

--- a/datalad_gooey/gooey.py
+++ b/datalad_gooey/gooey.py
@@ -2,6 +2,7 @@
 
 __docformat__ = 'restructuredtext'
 
+import datalad
 from datalad.interface.base import Interface
 from datalad.interface.base import build_doc
 from datalad.support.param import Parameter

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -224,6 +224,16 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="tabHelp">
+        <attribute name="title">
+         <string>Help</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QTextBrowser" name="helpBrowser"/>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </widget>
     </item>


### PR DESCRIPTION
The real feat would be an HTML rendering of the docs, but this requires a sphinx-integration.

For now just render a plain-text version and show it.

Closes #270