### PR TITLE
Give user explicit means to refresh the tree browser

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -496,6 +496,14 @@ class GooeyFilesystemBrowser(QObject):
             setbase.triggered.connect(self._app._set_root_path)
             context.addAction(setbase)
 
+        if item == self._root_item:
+            # for now this is the same as resetting the base to the same
+            # root -- but later it could be more clever
+            reload = QAction('&Refresh directory tree', context)
+            reload.setData(ipath)
+            reload.triggered.connect(self._app._set_root_path)
+            context.addAction(reload)
+
         if not context.isEmpty():
             # present the menu at the clicked point
             context.exec(self._tree.viewport().mapToGlobal(onpoint))


### PR DESCRIPTION
This should not be necessary, but maybe there are corner cases left, where it is needed, e.g. https://github.com/datalad/datalad-gooey/issues/239, or a user managed to KABOOM the tree population itself.

For now this is the simplest possible implementation (reload the whole thing). Later this could become more clever and more targeted.

Closes #239