### PR TITLE
Polish the Gin walk-through a little

### DIFF
--- a/docs/source/gin.rst
+++ b/docs/source/gin.rst
@@ -88,7 +88,7 @@ Finally we can confirm that our dataset can be obtained from GIN (possibly by ot
 Let's try making a clone in the same parent directory as our dataset, but under a different name.
 To do this, from the menu select *DataLad* → *Clone a dataset*.
 In the *Clone from* field, enter the dataset URL taken from GIN.
-Here, you can use either HTTPS (for public repositories) or SSH (for private repositories) URL.
+Here, you can use either the HTTPS (for public repositories) or SSH (for private repositories) URL.
 Note that when using HTTPS, you need to remove the ``.git`` from the URL ending for proper interaction with GIN.
 Next, click the directory selection icon to the right of *Clone into* field, and use the directory picker
 to create and select a new directory named, for example, ``cloned-dataset``.

--- a/docs/source/gin.rst
+++ b/docs/source/gin.rst
@@ -9,19 +9,21 @@ Prerequisites
 
 In order to use GIN for hosting and sharing your datasets, you need to:
 
-  - Register a GIN account
-  - Add a personal access token (for creation of repositories with DataLad)
-  - Add an SSH key (for uploading annexed contents)
+  - Register a GIN account;
+  - add a personal access token to your GIN account (for creation of repositories with DataLad);
+  - add an SSH key to your GIN account (for uploading annexed contents).
 
 Follow the instructions on GIN to do so.
-If you want to stay in the world of graphical interfaces, we recommend
-`PuTTYgen <https://www.puttygen.com/>`_ for SSH keys generation.
+
+If you need to generate an SSH key pair and want to stay in the world of graphical interfaces, we recommend using
+`PuTTYgen <https://www.puttygen.com/>`_ for this purpose.
+Your private key needs to be placed in the `.ssh` folder in your home directory for it to be picked up correctly.
 
 Create a dataset
 ----------------
 
 Let's assume that we are starting with an existing folder which already has some content, but is not yet a DataLad dataset.
-Let's open the DataLad gooey and set a base directory to our folder, or its parent directory.
+Let's open the DataLad Gooey and set a base directory to our folder, or its parent directory.
 
 Our first operation is to to create a DataLad dataset.
 For this, right-click your folder and select *Directory commands* → *Create a dataset*.
@@ -40,11 +42,15 @@ Save the contents
 
 Right-click the newly created dataset, and select *Dataset commands* → *Save the state in a dataset*.
 Parameters required for the Save command should appear in the Command tab.
-Fill in the *description of change* (this is the commit message associated with the save).
+Fill in the *Description of change* (this is the commit message associated with the save).
 Leave all other fields default (note: *Do not put files in annex* is greyed out, not checked, i.e. it has no value).
-Here, we are saving all files at once, but if we wanted we cauld limit the save operation to selected files,
+Here, we are saving all files at once, but if we wanted we could limit the save operation to selected files,
 or trigger it by clicking on a specific file.
-Once ready, click OK.
+Once ready, click *OK*.
+
+Note that after this operation, "untracked" files changed their state to "clean".
+Different from files, the dataset state is still "untracked", because it is not registered in any superdataset.
+Because we used the *text2git* configuration, only the PNG file changed its type to "annexed-file" in the screenshot below.
 
 .. image:: /_static/screenshots-gin/saved.png
 
@@ -59,10 +65,10 @@ You can leave all other options default.
 In the *Name of the credential to be used* field, you can pick previously used credentials.
 If no value is given, and no previous credentials exist, the credentials will be save with website name (`gin.g-node.org`) by default.
 
-Click OK.
+Click *OK*.
 
-At this point, you will be asked for a token.
-Paste the access token generated from GIN website, and click OK.
+At this point, a pop-up window will appear and you will be asked for a token.
+Paste the access token generated from GIN website, and click *OK*.
 
 .. image:: /_static/screenshots-gin/created-sibling.png
 
@@ -71,7 +77,7 @@ Push to the GIN sibling
 
 Right-click *Dataset commands* → *Push data/updates to a sibling*.
 The only thing you need to select is the value of *To dataset sibling* - this will be the sibling name from the step above.
-Click OK.
+Leave other options default, and click *OK*.
 
 .. image:: /_static/screenshots-gin/pushed.png
 
@@ -79,6 +85,17 @@ Retrieve the data from GIN
 --------------------------
 
 Finally we can confirm that our dataset can be obtained from GIN (possibly by other users who have access).
+Let's try making a clone in the same parent directory as our dataset, but under a different name.
+To do this, from the menu select *DataLad* → *Clone a dataset*.
+In the *Clone from* field, enter the dataset URL taken from GIN.
+Here, you can use either HTTPS (for public repositories) or SSH (for private repositories) URL.
+Note that when using HTTPS, you need to remove the ``.git`` from the URL ending for proper interaction with GIN.
+Next, click the directory selection icon to the right of *Clone into* field, and use the directory picker
+to create and select a new directory named, for example, ``cloned-dataset``.
+Afterwards, click *OK*.
 
-.. todo: describe cloning
-
+To obtain the annexed contents in the cloned dataset, right click it in the file tree, select
+*Dataset commands* → *Get content*, and click *OK*.
+With other options kept default, this will download all annexed content in the dataset;
+if you wanted to obtain contents selectively, you could use the *Limit to* option.
+Alternatively, you could right-click individual files, and use *File commands* → *Get content*.


### PR DESCRIPTION
Minor fixes to typos and punctuation or flow improvements.
Short explanations for SSH keys and file types.
Section on cloning (no screenshot), replacing todo.