### PR TITLE
Extend mixin API with helper for drag&drop event handling

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -43,6 +43,9 @@ class GooeyFilesystemBrowser(QObject):
         super().__init__()
 
         tw = treewidget
+        # enable dragging items, e.g. onto Path input widgets
+        tw.setDragEnabled(True)
+
         # disable until set_root() was called
         tw.setDisabled(True)
         self._tree = tw

--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -9,6 +9,7 @@ from PySide6.QtCore import (
     QDir,
     Qt,
     Signal,
+    QUrl,
 )
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -162,6 +163,58 @@ class GooeyParamWidgetMixin:
         of remotes after changing the reference dataset.
         """
         pass
+
+    #
+    # drag&drop related API
+    #
+    def _would_gooey_accept_drop_event(self, event: QDropEvent) -> bool:
+        """Helper of `_gooey_dragEnterEvent()`
+
+        Implement to indicate whether a drop event can be handled by a widget,
+        when `_gooey_dragEnterEvent()` is used to handle the event.
+        """
+        return False
+
+    def _would_gooey_accept_drop_url(self, url: QUrl):
+        """Helper of `MultiValueInputWidget`
+
+        Implement to let `MultiValueInputWidget` decide whether to pass URLs
+        from a drop event with multiple URLs on to the widget, url by url.
+        If the is implemented, `_set_gooey_drop_url_in_widget()` must also
+        be implemented.
+        """
+        return False
+
+    def _set_gooey_drop_url_in_widget(self, url: QUrl) -> None:
+        """Helper of `MultiValueInputWidget`
+
+        Implement to support setting the widget's value based on a URL from
+        a drop event. Called by `MultiValueInputWidget` when
+        `_would_gooey_accept_drop_url()` returned `True`.
+        """
+        raise NotImplementedError
+
+    def _gooey_dragEnterEvent(
+            self,
+            event: QDragEnterEvent,
+            # use a link action by default, so that the source/provider does
+            # not decide to remove the source when we accept
+            action: Qt.DropAction = Qt.DropAction.LinkAction) -> None:
+        """Standard implementation of drop event handling.
+
+        This implementation accepts or ignores and event based on the
+        return value of `_would_gooey_accept_drop_event()`. It can be
+        called by a widget's `dragEnterEvent()`.
+
+        This is not provided as a default implementation of `dragEnterEvent()`
+        directly in order to not override a widget specific implementation
+        provided by Qt.
+        """
+        if self._would_gooey_accept_drop_event(event):
+            event.setDropAction(action)
+            event.accept()
+        else:
+            event.ignore()
 
 
 def load_parameter_widget(
@@ -400,14 +453,6 @@ class PathParamWidget(QWidget, GooeyParamWidgetMixin):
         # treat an empty path as None
         self._set_gooey_param_value(val if val else None)
 
-    def _handle_drop(self, val):
-        if val:
-            self._edit.setText(str(val))
-            self._set_gooey_param_value(val)
-        else:
-            # TODO shouldn't happen, but add something to catch nevertheless?
-            return
-
     def set_gooey_param_docs(self, docs: str) -> None:
         # only use edit tooltip for the docs, and let the buttons
         # have their own
@@ -453,21 +498,42 @@ class PathParamWidget(QWidget, GooeyParamWidgetMixin):
         if 'dataset' in spec:
             self._basedir = spec['dataset']
 
+    def _would_gooey_accept_drop_event(self, event: QDropEvent):
+        if not event.mimeData().hasUrls():
+            return False
+
+        url = event.mimeData().urls()
+        if len(url) != 1:
+            # we can only handle a single url, ignore the event, to give
+            # a parent a chance to act
+            return False
+
+        url = url[0]
+
+        if not self._would_gooey_accept_drop_url(url):
+            return False
+
+        return True
+
+    def _would_gooey_accept_drop_url(self, url: QUrl):
+        """Return whether _set_gooey_drop_url_in_widget() would accept URL
+        """
+        return url.isLocalFile()
+
     def dragEnterEvent(self, event: QDragEnterEvent) -> None:
-        if event.mimeData().hasUrls():
-            event.setDropAction(Qt.DropAction.CopyAction)
-            event.acceptProposedAction()
-        else:
-            event.ignore()
-        return
+        self._gooey_dragEnterEvent(event)
 
     def dropEvent(self, event: QDropEvent) -> None:
-        if event.mimeData().hasUrls():
-            for url in event.mimeData().urls():
-                file = str(url.toLocalFile())
-                self._handle_drop(file)
-        else:
-            event.ignore()
+        # we did all the necessary checks before accepting the event in
+        # dragEnterEvent()
+        self._set_gooey_drop_url_in_widget(event.mimeData().urls()[0])
+
+    def _set_gooey_drop_url_in_widget(self, url: QUrl):
+        path = str(url.toLocalFile())
+        # setting the value in the widget will also trigger
+        # the necessary connections to also set the value in the
+        # mixin
+        self._edit.setText(path)
 
 
 class CfgProcParamWidget(ChoiceParamWidget):


### PR DESCRIPTION
This generalizes the previous implementation, and extends it to `MultiValueInputWidget`. This meta widget will not pass drop events onto an underlying editor widget, if that supports an event.

For unsupported events that comprise of URLs (e.g. `file://` URLs like one would get from a file manager), it passes them on, one-by-one, to the editor, and then builds new items from the editor representation of that URL (e.g. a path).

Drag and drop also works from the FS browser onto any Path input widget, including multi-value input of paths.

Closes #190
Closes #234


https://user-images.githubusercontent.com/136479/193039102-66327c71-6bb8-43ef-8f79-58d5303ee1d4.mp4

