### PR TITLE
Store/restore "main" geometry/state - window and the file tree header

### DIFF
--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MainWindow</class>
- <widget class="QMainWindow" name="MainWindow">
+ <widget class="GooeyQMainWindow" name="MainWindow">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/datalad_gooey/utils.py
+++ b/datalad_gooey/utils.py
@@ -18,13 +18,16 @@ class _NoValue:
     pass
 
 
-def load_ui(name, parent=None):
+def load_ui(name, parent=None, custom_widgets=None):
     ui_file_name = Path(__file__).parent / 'resources' / 'ui' / f"{name}.ui"
     ui_file = QFile(ui_file_name)
     if not ui_file.open(QIODevice.ReadOnly):
         raise RuntimeError(
             f"Cannot open {ui_file_name}: {ui_file.errorString()}")
     loader = QUiLoader()
+    if custom_widgets:
+        for custom_widget in custom_widgets:
+            loader.registerCustomWidget(custom_widget)
     ui = loader.load(ui_file, parentWidget=parent)
     ui_file.close()
     if not ui:


### PR DESCRIPTION
It felt inconvenient to need to rescale header (columns) in the tree view each time and/or make window bigger.  I guess there could be more geometries and states to store/restore but this is the main ones I felt need for.

I guess such functionality could become configurable, but as IMHO should be enabled by default for better UX decided to suggest hardcoded first.