### PR TITLE
Extend constraint concept to dataset context

### DIFF
--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 from .constraints import (
+    EnsureConfigProcedureName,
     EnsureDatasetSiblingName,
     EnsureExistingDirectory,
 )
@@ -53,6 +54,7 @@ api = dict(
         ),
         parameter_constraints=dict(
             path=EnsureExistingDirectory(),
+            cfg_proc=EnsureConfigProcedureName(),
         ),
     ),
     #create_sibling_gitlab=dict(


### PR DESCRIPTION
This implements and demos an idea from
https://github.com/datalad/datalad/issues/7054

With this change, a `Constraint` can implement a `for_dataset()` method that return an instance of another constraint (same or different type), tailored for a particular dataset instance.

This feature is demo'ed for `EnsureDatasetSiblingName`, which is `EnsureStr` without a dataset context, but generated an `EnsureChoice` with the names of the siblings of a particular dataset.

`EnsureDatasetSiblingName` is then used in `SiblingChoiceParamWidget`, which enables to move and re-use the sibling discovery to/from the constraint, rather than making the Qt-specific code longer.