### PR TITLE
Support for `argparse.REMAINDER`

### DIFF
--- a/datalad_gooey/param_form_utils.py
+++ b/datalad_gooey/param_form_utils.py
@@ -271,8 +271,13 @@ def _get_parameter_widget_factory(
                 # TODO give a fixed N as a parameter too
                 MultiValueInputWidget, type_widget)
     else:
-        if nargs in ('+', '*') or argparse_action == 'append':
+        import argparse
+        if (nargs in ('+', '*', argparse.REMAINDER)
+                or argparse_action == 'append'):
             type_widget = functools.partial(
                 MultiValueInputWidget, type_widget)
+        else:
+            print("WTF", name, nargs, type(nargs))
+
 
     return type_widget


### PR DESCRIPTION
Which is for Gooey's purpose equal to `nargs=*`

Closes datalad/datalad-gooey#89

This furthers the usability of

- `create`
- `clone`
- `run`
- `export_archive_ora`
- `foreach_dataset`
- `run_procedure`

in the `gooey-complete` suite.