### PR TITLE
`EnsureIterableOf` with generator compatibility and length check

### DIFF
--- a/datalad_gooey/tests/test_constraints.py
+++ b/datalad_gooey/tests/test_constraints.py
@@ -9,6 +9,9 @@ from ..constraints import (
     EnsureStr,
     EnsureGitRefName,
     EnsurePath,
+    EnsureIterableOf,
+    EnsureListOf,
+    EnsureTupleOf,
 )
 
 
@@ -74,6 +77,61 @@ def test_EnsureStr_match():
     for v in ('', '123_abc'):
         with pytest.raises(ValueError):
             assert constraint('')
+
+
+# imported from ancient test code in datalad-core,
+# main test is test_EnsureIterableOf
+def test_EnsureTupleOf():
+    c = EnsureTupleOf(str)
+    assert c(['a', 'b']) == ('a', 'b')
+    assert c(['a1', 'b2']) == ('a1', 'b2')
+    assert c.short_description() == "tuple(<class 'str'>)"
+
+
+# imported from ancient test code in datalad-core,
+# main test is test_EnsureIterableOf
+def test_EnsureListOf():
+    c = EnsureListOf(str)
+    assert c(['a', 'b']) == ['a', 'b']
+    assert c(['a1', 'b2']) == ['a1', 'b2']
+    assert c.short_description() == "list(<class 'str'>)"
+
+
+def test_EnsureIterableOf():
+    assert EnsureIterableOf(
+        list, int).short_description() == "<class 'list'>(<class 'int'>)"
+    # testing aspects that are not covered by test_EnsureListOf
+    tgt = [True, False, True]
+    assert EnsureIterableOf(list, bool)((1, 0, 1)) == tgt
+    assert EnsureIterableOf(list, bool, min_len=3, max_len=3)((1, 0, 1)) == tgt
+    with pytest.raises(ValueError):
+        # too many items
+        EnsureIterableOf(list, bool, max_len=2)((1, 0, 1))
+    with pytest.raises(ValueError):
+        # too few items
+        EnsureIterableOf(list, bool, min_len=4)((1, 0, 1))
+    with pytest.raises(ValueError):
+        # invalid specification min>max
+        EnsureIterableOf(list, bool, min_len=1, max_len=0)
+    with pytest.raises(TypeError):
+        # item_constraint fails
+        EnsureIterableOf(list, dict)([5.6, 3.2])
+    with pytest.raises(ValueError):
+        # item_constraint fails
+        EnsureIterableOf(list, EnsureBool())([5.6, 3.2])
+
+    seq = [3.3, 1, 2.6]
+
+    def _mygen():
+        for i in seq:
+            yield i
+
+    def _myiter(iter):
+        for i in iter:
+            yield i
+
+    # feeding a generator into EnsureIterableOf and getting one out
+    assert list(EnsureIterableOf(_myiter, int)(_mygen())) == [3, 1, 2]
 
 
 def test_EnsureMapping():


### PR DESCRIPTION
This is a precondition for addressing
https://github.com/datalad/datalad-gooey/issues/284

New versions of -core's `EnsureListOf` and `EnsureTupleOf` are also included. They used to be independent implementations as near-copies. The new implementation merely parameterizes `EnsureIterableOf`.

Ping https://github.com/datalad/datalad/issues/7054