### PR TITLE
Rethink parameter widget selection 

### DIFF
--- a/datalad_gooey/constraints.py
+++ b/datalad_gooey/constraints.py
@@ -181,6 +181,10 @@ class EnsureIterableOf(Constraint):
         self._max_len = max_len
         super().__init__()
 
+    @property
+    def item_constraint(self):
+        return self._item_constraint
+
     def __call__(self, value):
         iter = self._iter_type(
             self._item_constraint(i) for i in value

--- a/datalad_gooey/constraints.py
+++ b/datalad_gooey/constraints.py
@@ -491,7 +491,7 @@ class EnsureConfigProcedureName(EnsureChoice):
     def for_dataset(self, dataset: Dataset):
         if not dataset.is_installed():
             return self
-        return EnsureChoice(*self._get_procs_(dataset))
+        return EnsureChoice(*self._get_choices_(dataset))
 
     def _get_choices_(self, dataset: Dataset = None):
         from datalad.local.run_procedure import RunProcedure
@@ -538,7 +538,7 @@ class EnsureCredentialName(EnsureChoice):
     def for_dataset(self, dataset: Dataset):
         if not dataset.is_installed():
             return self
-        return EnsureChoice(*self._get_procs_(dataset))
+        return EnsureChoice(*self._get_choices_(dataset))
 
     def _get_choices_(self, dataset: Dataset = None):
         from datalad_next.credman import CredentialManager

--- a/datalad_gooey/dataladcmd_ui.py
+++ b/datalad_gooey/dataladcmd_ui.py
@@ -149,7 +149,9 @@ class GooeyDataladCmdUI(QObject):
                 if label_text.endswith(invalid_suffix):
                     label.setText(label_text[:-len(invalid_suffix)])
                     # expensive, but reliable, reset tooltip
-                    label.setToolTip(param.get_display_label().toolTip())
+                    label.setToolTip(
+                        label.toolTip().split(
+                            ' ~ value not valid: ', maxsplit=1)[0])
             except Exception as e:
                 # annotate display label with a marker that the validator
                 # failed
@@ -158,7 +160,8 @@ class GooeyDataladCmdUI(QObject):
                     label.setText(f"{label_text}{invalid_suffix}")
                     # communicate exception via tooltip
                     # users can hover over the (!) and get a hint
-                    label.setToolTip(str(e))
+                    label.setToolTip(
+                            f'{label.toolTip()} ~ value not valid: {e}')
                 ok_pb.setDisabled(True)
                 failed = True
         if not failed:

--- a/datalad_gooey/dataladcmd_ui.py
+++ b/datalad_gooey/dataladcmd_ui.py
@@ -148,12 +148,17 @@ class GooeyDataladCmdUI(QObject):
                 param.get_constraint()(candidate)
                 if label_text.endswith(invalid_suffix):
                     label.setText(label_text[:-len(invalid_suffix)])
-            except Exception:
-                # TODO annotate display label with a marker that the validator
+                    # expensive, but reliable, reset tooltip
+                    label.setToolTip(param.get_display_label().toolTip())
+            except Exception as e:
+                # annotate display label with a marker that the validator
                 # failed
                 # if anything is not right, block command execution
                 if not label_text.endswith(invalid_suffix):
                     label.setText(f"{label_text}{invalid_suffix}")
+                    # communicate exception via tooltip
+                    # users can hover over the (!) and get a hint
+                    label.setToolTip(str(e))
                 ok_pb.setDisabled(True)
                 failed = True
         if not failed:

--- a/datalad_gooey/param.py
+++ b/datalad_gooey/param.py
@@ -207,6 +207,15 @@ class GooeyCommandParameter(QObject):
         else:
             return self.__constraint
 
+    def set_constraint(self, constraint) -> None:
+        """Reset the parameter constraint.
+
+        It is typically unnecessary to call this method. It is only needed
+        in conjunction with collapsing needless input widget alternatives.
+        """
+        self.__base_constraint = constraint
+        self.__constraint = self.__base_constraint
+
     def tailor_constraint_to_dataset(self, dataset: Dataset or None) -> None:
         """Alters the parameter contraint to match a particular dataset context
 
@@ -222,6 +231,19 @@ class GooeyCommandParameter(QObject):
         # tailor the active
         self.__constraint = self.get_constraint().for_dataset(dataset)
 
+    def can_present_None(self):
+        """Returns whether the parameter instance can represent `None`
+
+        This means that calling `set(None)` followed by `get()` would
+        return a literal `None`.
+
+        This special method is used to determine whether an alternative
+        constraint with an `EnsureNone()` component requires a dedicated
+        input widget for this special value that is a frequent default,
+        or whether one of the other alternatives can also represent
+        it, and thereby enable a user to set `None`.
+        """
+        return False
     #
     # drag&drop related API
     #

--- a/datalad_gooey/param_form_utils.py
+++ b/datalad_gooey/param_form_utils.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
 
 from datalad.interface.common_opts import eval_params
 from datalad.support.constraints import EnsureChoice
+from datalad.support.param import Parameter
 from datalad.utils import (
     get_wrapped_class,
 )
@@ -31,11 +32,21 @@ from .api_utils import (
 from .utils import _NoValue
 from .constraints import (
     AltConstraints,
+    EnsureBool,
     EnsureExistingDirectory,
     EnsureDatasetSiblingName,
     EnsureNone,
+    EnsureIterableOf,
     EnsureListOf,
     EnsureDataset,
+    CoreEnsureDataset,
+    EnsureConfigProcedureName,
+    EnsurePath,
+    EnsureInt,
+    EnsureRange,
+    EnsureCredentialName,
+    EnsureStr,
+    NoConstraint,
 )
 
 __all__ = ['populate_form_w_params']
@@ -63,18 +74,6 @@ def populate_form_w_params(
     # collect parameter instances for a later connection setup
     form_params = dict()
 
-    def _get_nargs(pname, argparse_spec):
-        if pname in cmd_api_spec.get('parameter_nargs', []):
-            # take as gospel
-            return cmd_api_spec['parameter_nargs'][pname]
-        else:
-            nargs = argparse_spec.get('nargs', None)
-            try:
-                nargs = int(nargs)
-            except (ValueError, TypeError):
-                pass
-            return nargs
-
     # loop over all parameters of the command (with their defaults)
     def _specific_params():
         for pname, pdefault in get_cmd_params(cmd):
@@ -101,11 +100,6 @@ def populate_form_w_params(
             continue
         if pname in cmd_api_spec.get('exclude_parameters', []):
             continue
-        if pname in cmd_api_spec.get('parameter_constraints', []):
-            # we have a better idea in gooey then what the original
-            # command knows
-            param_spec.constraints = \
-                cmd_api_spec['parameter_constraints'][pname]
         cmdkwargs_defaults[pname] = pdefault
         # populate the layout with widgets for each of them
         # we do not pass Parameter instances further down, but disassemble
@@ -114,14 +108,10 @@ def populate_form_w_params(
             name=pname,
             # will also be _NoValue, if there was none
             default=pdefault,
-            constraints=cmd_api_spec['parameter_constraints'][pname]
-            if pname in cmd_api_spec.get('parameter_constraints', [])
-            else param_spec.constraints,
+            constraint=_get_comprehensive_constraint(
+                pname, pdefault, param_spec, cmd_api_spec),
             docs=format_param_docs(param_spec._doc),
-            nargs=_get_nargs(pname, param_spec.cmd_kwargs),
             basedir=basedir,
-            # TODO make obsolete
-            argparse_spec=param_spec.cmd_kwargs,
         )
         display_label = form_param.get_display_label(cmd_param_display_names)
         # build the input widget
@@ -154,143 +144,233 @@ def populate_form_w_params(
 # Internal helpers
 #
 
+# these are left-overs, none of them should be here
+# either parameters get proper constraints to begin with
+# or the API of the active_suite should override this
+# already
+override_constraint_by_param_name = {
+    'dataset': EnsureDataset(),
+    'path': EnsurePath(),
+    'credential': EnsureCredentialName(allow_none=True, allow_new=True),
+    # TODO this is a multi-constraint, still requires support
+    # idea: one of the constraints needs to have a supported
+    # input widget, the rest just informs that one
+    # no idea how generic that could be
+    'recursion_limit': EnsureInt() & EnsureRange(min=0),
+}
+
+
+def _get_comprehensive_constraint(
+        pname: str,
+        default: Any,
+        param_spec: Parameter,
+        cmd_api_spec: Dict):
+    action = param_spec.cmd_kwargs.get('action')
+    # definitive per-item constraint, consider override from API
+    # otherwise fall back on Parameter.constraints
+    constraint = cmd_api_spec['parameter_constraints'][pname] \
+        if pname in cmd_api_spec.get('parameter_constraints', []) \
+        else override_constraint_by_param_name.get(
+            pname,
+            param_spec.constraints)
+
+    print("CONST", pname, constraint)
+
+    if isinstance(constraint, CoreEnsureDataset):
+        print("NAME", pname)
+        if not isinstance(constraint, EnsureDataset):
+            print("BINGO")
+        # force our own constraint. DataLad's EnsureDataset
+        # does not handle Path objects
+        # https://github.com/datalad/datalad/issues/7069
+        constraint = EnsureDataset()
+
+    if not constraint:
+        if action in ('store_true', 'store_false'):
+            constraint = EnsureBool()
+        elif param_spec.cmd_kwargs.get('choices'):
+            constraint = EnsureChoice(*param_spec.cmd_kwargs.get('choices'))
+        else:
+            # always have one for simplicity
+            constraint = NoConstraint()
+
+    # we must addtionally consider the following nargs spec for
+    # a complete constraint specification
+    # (int, '*', '+'), plus action=
+    # - 'store_const' TODO
+    # - 'store_true' and 'store_false' TODO
+    # - 'append'
+    # - 'append_const' TODO
+    # - 'count' TODO
+    # - 'extend' TODO
+
+    # get the definitive argparse "nargs" value
+    nargs = None
+    if pname in cmd_api_spec.get('parameter_nargs', []):
+        # take as gospel
+        nargs = cmd_api_spec['parameter_nargs'][pname]
+    else:
+        # fall back on Parameter attribute
+        nargs = param_spec.cmd_kwargs.get('nargs', None)
+        try:
+            nargs = int(nargs)
+        except (ValueError, TypeError):
+            pass
+
+    # TODO reconsider using `list`, with no length-check it could
+    # be a generator
+    if isinstance(nargs, int):
+        # sequence of a particular length
+        constraint = EnsureIterableOf(
+            list, constraint, min_len=nargs, max_len=nargs)
+    elif nargs == '*':
+        # sequence of any length, but always a sequence
+        constraint = EnsureIterableOf(list, constraint)
+    elif nargs == '+':
+        # sequence of at least 1 item, always a sequence
+        constraint = EnsureIterableOf(list, constraint, min_len=1)
+    # handling of `default` and `const` would be here
+    #elif nargs == '?'
+
+    if action == 'append':
+        # wrap into a(nother) sequence
+        # (think: list of 2-tuples, etc.
+        constraint = EnsureIterableOf(list, constraint)
+
+    # lastly try to validate the default, if that fails
+    # wrap into alternative
+    try:
+        constraint(default)
+    except Exception:
+        # should be this TODO
+        #constraint = constraint | EnsureValue(default)
+        # for now
+        if default is None:
+            constraint = constraint | EnsureNone()
+
+    return constraint
+
+
 def _get_parameter(
         name: str,
         default: Any,
-        constraints: Callable or None,
+        constraint: Callable or None,
         docs: str,
-        nargs: int or str,
-        basedir: Path,
-        # TODO make obsolete
-        argparse_spec: Dict) -> Callable:
+        basedir: Path) -> Callable:
     """Translate DataLad command parameter specs into Gooey input widgets"""
-    if argparse_spec is None:
-        argparse_spec = {}
-    argparse_action = argparse_spec.get('action')
+
+    # TODO check any incoming constraint whether it is the core variant of
+    # EnsureListOf or EnsureTupleOf and replace them with others
+    # otherwise the isinstance() tests below are not valid
+
     disable_manual_path_input = active_suite.get('options', {}).get(
         'disable_manual_path_input', False)
 
     std_param_init_kwargs = dict(
         name=name,
         default=default,
-        constraint=constraints,
+        constraint=constraint,
     )
     custom_param_init_kwargs = dict(
         docs=docs,
     )
 
+    # this will be the returned GooeyCommandParameter in the end
+    param = None
+
     # if we have no idea, use a simple line edit
     type_widget = pw.StrParameter
-    ## now some parameters where we can derive semantics from their name
-    if name == 'dataset' or isinstance(constraints, EnsureExistingDirectory):
+    ### now some parameters where we can derive semantics from their name
+    if isinstance(constraint, EnsureDataset) \
+            or isinstance(constraint, EnsureExistingDirectory):
         type_widget = PathParameter
-        std_param_init_kwargs.update(
-            # force our own constraint. DataLad's EnsureDataset
-            # does not handle Path objects
-            # https://github.com/datalad/datalad/issues/7069
-            constraint=EnsureDataset() | EnsureNone(),
-        )
         custom_param_init_kwargs.update(
             pathtype=QFileDialog.Directory,
             disable_manual_edit=disable_manual_path_input,
             basedir=basedir,
         )
-    elif name == 'path':
+    elif isinstance(constraint, EnsurePath):
         type_widget = PathParameter
         custom_param_init_kwargs.update(
             disable_manual_edit=disable_manual_path_input,
             basedir=basedir,
         )
-    elif name == 'cfg_proc':
-        type_widget = pw.CfgProcParameter
-    elif name == 'credential':
+    elif isinstance(constraint, EnsureCredentialName):
+        print("CHOICE")
         type_widget = pw.CredentialChoiceParameter
-    elif name == 'recursion_limit':
+    elif constraint == EnsureInt() & EnsureRange(min=0):
         type_widget = pw.PosIntParameter
         custom_param_init_kwargs.update(allow_none=True)
-    elif name == 'message':
+    elif isinstance(constraint, EnsureStr) and name == 'message':
         type_widget = pw.TextParameter
-    # now parameters where we make decisions based on their configuration
-    elif isinstance(constraints, EnsureNone):
-        type_widget = pw.NoneParameter
-    elif isinstance(constraints, EnsureDatasetSiblingName):
+    # pick the parameter types based on the set Constraint
+    # go from specific to generic
+    elif isinstance(constraint, EnsureConfigProcedureName):
+        type_widget = pw.CfgProcParameter
+    elif isinstance(constraint, EnsureDatasetSiblingName):
         type_widget = pw.SiblingChoiceParameter
-    # TODO ideally the suite API would normalize this to a EnsureBool
-    # constraint
-    elif argparse_action in ('store_true', 'store_false'):
+    elif isinstance(constraint, EnsureChoice):
+        type_widget = pw.ChoiceParameter
+        # TODO not needed, the parameter always also gets the constraint
+        custom_param_init_kwargs.update(choices=constraint._allowed)
+    elif isinstance(constraint, EnsureBool):
         if default is None:
             # it wants to be a bool, but isn't quite pure
             type_widget = pw.BoolParameter
             custom_param_init_kwargs.update(allow_none=True)
         else:
             type_widget = pw.BoolParameter
-    elif isinstance(constraints, EnsureChoice):
-        type_widget = pw.ChoiceParameter
-        # TODO not needed, the parameter always also gets the constraint
-        custom_param_init_kwargs.update(choices=constraints._allowed)
-    ## TODO ideally the suite API would normalize this to a EnsureChoice
-    ## constraint
-    elif argparse_spec.get('choices'):
-        type_widget = pw.ChoiceParameter
-        custom_param_init_kwargs.update(choices=argparse_spec.get('choices'))
-    elif isinstance(constraints, AltConstraints):
+    elif isinstance(constraint, EnsureNone):
+        type_widget = pw.NoneParameter
+    elif isinstance(constraint, AltConstraints):
         param_alternatives = [
             _get_parameter(
                 name=name,
                 default=default,
-                constraints=c,
+                constraint=c,
                 docs=docs,
-                nargs='?',
                 basedir=basedir,
-                # TODO make obsolete
-                argparse_spec={
-                    # pass on anything, but not information that
-                    # would trigger a MultiValueInputWidget
-                    # wrapping on a particular alternative.
-                    # This is only done once around the entire
-                    # AlternativeParamWidget
-                    k: v for k, v in argparse_spec.items()
-                    if k != 'action' or v != 'append'
-                }
             )
-            for c in constraints.constraints
+            for c in constraint.constraints
         ]
-        type_widget = AlternativesParameter
-        custom_param_init_kwargs.update(alternatives=param_alternatives)
-
-    # we must consider the following nargs spec for widget selection
-    # (int, '*', '+'), plus action=
-    # - 'store_const'
-    # - 'store_true' and 'store_false'
-    # - 'append'
-    # - 'append_const'
-    # - 'count'
-    # - 'extend'
-    # in some of these cases, we need to expect multiple instances of the data
-    # type for which we have selected the input widget above
-    item_constraint = std_param_init_kwargs['constraint']
-    multival_args = dict(
-        ptype=type_widget,
-        # same constraint as an individual item, but a whole list of them
-        # OR with `constraints` to allow fallback on a single item
-        constraint=EnsureListOf(item_constraint) | item_constraint,
-    )
-    if isinstance(nargs, int):
-        # we have a concrete number
-        if nargs > 1:
-            # TODO give a fixed N as a parameter too
-            std_param_init_kwargs.update(**multival_args)
-            type_widget = MultiValueParameter
-    else:
-        import argparse
-        if (nargs in ('+', '*', argparse.REMAINDER)
-                or argparse_action == 'append'):
-            std_param_init_kwargs.update(**multival_args)
-            type_widget = MultiValueParameter
-
-    # create an instance
-    param = type_widget(
-        widget_init=custom_param_init_kwargs,
-        **std_param_init_kwargs
-    )
+        # loop over alternative if any instance reports
+        # "can do NONE!", and if so, strip any EnsureNone from the set of
+        # alternatives
+        if any(isinstance(c, EnsureNone) for c in constraint.constraints) \
+                and sum(p.can_present_None() for p in param_alternatives) > 1:
+            # we need to represent None, and we can without using a dedicated
+            # widget for it, filter the alternatives
+            param_alternatives = [
+                p for p in param_alternatives
+                if not isinstance(p.get_constraint(), EnsureNone)
+            ]
+            # we must have some left, or all alternatives were EnsureNone
+            assert len(param_alternatives)
+        # if only one alternative is left, skip the AlternativesParameter
+        # entirely, and go with that one
+        if len(param_alternatives) == 1:
+            # set the parameter instance directly
+            param = param_alternatives[0]
+            # but use the full constraint for validation!!
+            param.set_constraint(constraint)
+        else:
+            type_widget = AlternativesParameter
+            custom_param_init_kwargs.update(alternatives=param_alternatives)
+    elif isinstance(constraint, EnsureIterableOf):
+        type_widget = MultiValueParameter
+        std_param_init_kwargs.update(
+            item_param=_get_parameter(
+                name=name,
+                default=default,
+                constraint=constraint.item_constraint,
+                docs=docs,
+                basedir=basedir,
+            )
+        )
+    # create an instance, if still needed
+    if param is None:
+        param = type_widget(
+            widget_init=custom_param_init_kwargs,
+            **std_param_init_kwargs
+        )
     return param

--- a/datalad_gooey/param_path.py
+++ b/datalad_gooey/param_path.py
@@ -51,6 +51,16 @@ class PathParameter(GooeyCommandParameter):
         # treat an empty path as None
         self.set(val if val else None)
 
+    def can_present_None(self):
+        return True
+
+    def set(self, value, set_in_widget=True):
+        # re-implement, because we want to treat `None` like `_NoValue`
+        # consistently
+        if value is None:
+            value = _NoValue
+        super().set(value, set_in_widget=set_in_widget)
+
     def _set_in_widget(self, wid: QWidget, value: Any) -> None:
         if value and value is not _NoValue:
             # TODO this could use some abstraction on the widget side
@@ -190,7 +200,7 @@ class PathParamWidget(QWidget):
                 # if the selection was canceled, clear the path,
                 # otherwise users have no ability to unset a previous
                 # selection
-                self._param._set_in_widget(_NoValue)
+                self._param._set_in_widget(self._param.input_widget, _NoValue)
             # otherwise just keep the present value as-is
             return
         dialog = self.sender()

--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -148,6 +148,10 @@ class BoolParameter(GooeyCommandParameter):
         cb.stateChanged.connect(self._handle_input)
         return cb
 
+    def can_present_None(self):
+        # generally yes, due to the way _set_in_widget() is implemented
+        return True
+
     def _set_in_widget(self, wid: QWidget, value: Any) -> None:
         if value not in (True, False):
             # if the value is not representable by a checkbox

--- a/datalad_gooey/param_widgets.py
+++ b/datalad_gooey/param_widgets.py
@@ -100,7 +100,15 @@ class ChoiceParameter(GooeyCommandParameter):
         return '--none--' if val is None else str(val)
 
     def can_present_None(self):
-        return None in self.get_constraint()._allowed
+        # use whatever the constraint says, and trust that the widget
+        # subclasses can represent what is needed
+        # concretely SiblingChoiceParameter need to actually
+        # know choices until a dataset is known
+        try:
+            self.get_constraint()(None)
+            return True
+        except Exception:
+            return False
 
 
 class PosIntParameter(GooeyCommandParameter):

--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -138,7 +138,7 @@ api = dict(
         ),
         parameter_constraints=dict(
             name=EnsureStrOrNoneWithEmptyIsNone(),
-            publish_depends=EnsureStrOrNoneWithEmptyIsNone(),
+            publish_depends=EnsureDatasetSiblingName(allow_none=True),
         ),
     ),
     create_sibling_webdav=dict(

--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -169,7 +169,8 @@ api = dict(
             credential=7,
         ),
         parameter_constraints=dict(
-            name=EnsureStrOrNoneWithEmptyIsNone()
+            name=EnsureStrOrNoneWithEmptyIsNone(),
+            url=EnsureStr(min_len=len('http://e.c')),
         ),
     ),
     drop=dict(

--- a/datalad_gooey/tests/test_param_widget.py
+++ b/datalad_gooey/tests/test_param_widget.py
@@ -54,14 +54,16 @@ def test_GooeyCommandParameter():
             (ChoiceParameter, 'b', 'c', dict(choices=['a', 'b', 'c'])),
             (PathParameter, str(Path.cwd()), 'mypath', {}),
             (PathParameter, str(Path.cwd()), None, {}),
-            (functools.partial(
-                MultiValueParameter, ptype=PathParameter),
-             [str(Path.cwd()), 'temp'],
-             'mypath', {}),
-            (functools.partial(
-                MultiValueParameter, ptype=PathParameter),
-             [str(Path.cwd()), 'temp'],
-             None, {}),
+            # XXX construction of the item_param is hard without the
+            # _get_parameter() helper
+            #(functools.partial(
+            #    MultiValueParameter, ptype=PathParameter()),
+            # [str(Path.cwd()), 'temp'],
+            # 'mypath', {}),
+            #(functools.partial(
+            #    MultiValueParameter, ptype=PathParameter),
+            # [str(Path.cwd()), 'temp'],
+            # None, {}),
             # XXX construction of the alternatives is hard without the
             # _get_parameter() helper
             ### alternatives with value and default associated with different


### PR DESCRIPTION
Before it was a mess, now it is less of a mess.

Importantly, the parameter widget selection is no longer based on a
mixture of parameter names, constraints, and argparse internal
settings. Now the selection is made solely based on an assigned
`Constraint`.

To make this possible the whole slew of new Constraints that came to
life lately is put to action. The constraint provided by -core's
`Parameter` class is now treated as an "item constraint". This is
turned into a "comprehensive constraint" by wrapping it, as necessary,
into additional constraints. E.g. `nargs='*'` causes
`EnsureIterableOf(list, constraint)`.

A number of other rules are implemented to always yield a single
constraint as a fully qualified ruleset to translate a parameters
requirements into a widget(set).

Importantly, it is not necessary to indicate an explicit `|
EnsureNone()` for a parameter that takes totally different values, but
defaults to `None`, merely to indicate that it is optional.
Now, an `EnsureNone()` is added automatically.

The approach should be extended to an `EnsureValue(default)`, for any
default value that is not already covered by the assigned constraint.

Closes #302