### PR TITLE
improve build step name

### DIFF
--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Build installer
+      - name: Build windows 64-bit installer
         run: |
           cd tools\installer_building
           $build_out = .\build_windows_installer.ps1 ${{ inputs.revision }}


### PR DESCRIPTION
This PR just changes the name of one of the steps of the windows installer build-workflow. This is mainly done to create
a new PR in order to approve the new workflow.
