### PR TITLE
Metadata editor framework

### DIFF
--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -202,11 +202,17 @@ class AnnexMetadataEditor(MetadataEditor):
 
     def _add_field_value_add_pb(self, group_id, layout):
         # '+' button to add a new value
-        pb = QPushButton(self)
+        frame = QFrame(self)
+        frame.setFrameStyle(QFrame.StyledPanel)
+        pb = QToolButton(frame)
         pb.setText('+')
         pb.clicked.connect(lambda: self._on_add_field_value_clicked(
-            group_id, replace=pb))
-        layout.addWidget(pb)
+            group_id, replace=frame))
+        bl = QVBoxLayout()
+        bl.setContentsMargins(0, 0, 0, 0)
+        bl.addWidget(pb)
+        frame.setLayout(bl)
+        layout.addWidget(frame)
         self.enable_save()
 
     def _find_form_row_by_name_widget(self, widget):

--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -17,7 +17,6 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtGui import (
     QValidator,
-    QFontMetrics,
     QPixmap,
 )
 from PySide6.QtCore import (
@@ -29,6 +28,29 @@ from .flowlayout import FlowLayout
 
 
 class AnnexMetadataEditor(MetadataEditor):
+    """Git-annex metadata editor
+
+    Git-annex supports assigning metadata to any "annexed" file in a dataset.
+    More precisely, such metadata are associated with the underlying annex-key,
+    the content identifier. Therefore, multiple files that have the exact same
+    content will also report the same metadata record. When a file with
+    git-annex metadata is modified, the metadata of the previous version will
+    be copied to the new annex-key when the modified file is saved in the
+    dataset.
+
+    Each metadata record can have any number of metadata fields, which each can
+    have any number of values. For example, to tag files, the "tag" field is
+    typically used, with values set to each tag that applies to the file.
+
+    The field names are limited to alphanumerics (and [_-.]), and are case
+    insensitive. The metadata values can contain any text.
+
+    Importantly, both metadata field names and all values of a particular field
+    are technically a set, there cannot be duplicate values.
+
+    To remove an entire field from an existing metadata record, all of its
+    values have to be removed.
+    """
     # used as the widget title
     _widget_title = 'Annex metadata'
 

--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -39,11 +39,14 @@ class AnnexMetadataEditor(MetadataEditor):
         self.__path = None
 
         editor_layout = QVBoxLayout()
-        #editor_layout.setContentsMargins(0, 0, 0, 0)
+        editor_layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(editor_layout)
         # first the form with the fields
         self.__field_form = QFormLayout()
-        #self.__field_form.setContentsMargins(0, 0, 0, 0)
+        # enforce alignment across platforms, flow layout looks weird
+        # with centered items
+        self.__field_form.setFormAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.__field_form.setContentsMargins(0, 0, 0, 0)
         self.__field_form.addRow(
             QLabel('Field'),
             QLabel('Value'),

--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -7,10 +7,12 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QFormLayout,
     QPushButton,
+    QToolButton,
     QDialogButtonBox,
     QWidget,
     QLineEdit,
     QStyle,
+    QFrame,
 )
 from PySide6.QtGui import (
     QValidator,
@@ -238,7 +240,7 @@ class AnnexMetadataEditor(MetadataEditor):
             layout.removeWidget(item)
 
 
-class ItemWidget(QWidget):
+class ItemWidget(QFrame):
     # track fields for a particular path across all class
     # instances
     _field_tracker = dict()
@@ -259,24 +261,29 @@ class ItemWidget(QWidget):
         items = self._field_tracker[group_id]
         items.add(self)
 
+        self.setFrameStyle(QFrame.StyledPanel)
+        # all components in a horizontal arrangement
         layout = QHBoxLayout()
+        # tight fit
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
-        db = QPushButton(self)
-        db.setIcon(self.style().standardIcon(QStyle.SP_DialogDiscardButton))
-        db.clicked.connect(lambda: editor._discard_item(self))
-        layout.addWidget(db)
+        # edit first
         edit = QLineEdit(self)
         edit.setClearButtonEnabled(True)
-        #edit.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         edit.textChanged.connect(self._on_textchanged)
         edit.editingFinished.connect(self._on_editingfinished)
         edit.setValidator(ItemWidget._validators[group_id])
         layout.addWidget(edit)
         self.__editor = edit
+        # state label
         state = QLabel(self)
         self.__state_label = state
         layout.addWidget(state)
+        # discard button
+        db = QToolButton(self)
+        db.setIcon(self.style().standardIcon(QStyle.SP_DialogDiscardButton))
+        db.clicked.connect(lambda: editor._discard_item(self))
+        layout.addWidget(db)
 
     def closeEvent(self, *args, **kwargs):
         # unregister this item from its parent group

--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -26,6 +26,9 @@ from .flowlayout import FlowLayout
 
 
 class AnnexMetadataEditor(MetadataEditor):
+    # used as the widget title
+    _widget_title = 'Annex metadata'
+
     def __init__(self, parent):
         super().__init__(parent)
 
@@ -59,6 +62,7 @@ class AnnexMetadataEditor(MetadataEditor):
         bbx.accepted.connect(self._save_metadata)
         self.__bbx = bbx
         editor_layout.addWidget(bbx)
+        editor_layout.addStretch()
 
     def set_path(self, path: Path):
         self.__path = path

--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -316,6 +316,10 @@ class ItemWidget(QWidget):
             pixmap = QPixmap(0, 0)
         else:
             pixmap = self.style().standardPixmap(stdpixmap)
+        # shrink the standard pixmap to the height of the editor
+        # if it happens to be humongous in some platform
+        if pixmap.size().height() > self.__editor.size().height():
+            pixmap = pixmap.scaledToHeight(self.__editor.size().height())
         self.__state_label.setPixmap(pixmap)
 
         if not tooltip:

--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -1,20 +1,373 @@
 from pathlib import Path
+from typing import Any
 
 from PySide6.QtWidgets import (
     QLabel,
+    QHBoxLayout,
     QVBoxLayout,
+    QFormLayout,
+    QPushButton,
+    QDialogButtonBox,
+    QWidget,
+    QLineEdit,
+    QStyle,
+)
+from PySide6.QtGui import (
+    QValidator,
+    QFontMetrics,
+    QPixmap,
+)
+from PySide6.QtCore import (
+    Qt,
 )
 
 from .metadata_editor_base import MetadataEditor
+from .flowlayout import FlowLayout
 
 
 class AnnexMetadataEditor(MetadataEditor):
     def __init__(self, parent):
         super().__init__(parent)
-        layout = QVBoxLayout()
-        self.setLayout(layout)
-        label = QLabel('Annex!')
-        layout.addWidget(label)
+
+        # all field edits
+        self.__fields = []
+        self.__path = None
+
+        editor_layout = QVBoxLayout()
+        #editor_layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(editor_layout)
+        # first the form with the fields
+        self.__field_form = QFormLayout()
+        #self.__field_form.setContentsMargins(0, 0, 0, 0)
+        self.__field_form.addRow(
+            QLabel('Field'),
+            QLabel('Value'),
+        )
+        editor_layout.addLayout(self.__field_form)
+        # button to add a field
+        add_field_pb = QPushButton("Add field", self)
+        add_field_pb.clicked.connect(self._on_addfield_clicked)
+        addf_layout = QHBoxLayout()
+        addf_layout.addWidget(add_field_pb)
+        addf_layout.addStretch()
+        editor_layout.addLayout(addf_layout)
+        # button box to save/cancel
+        bbx = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        # on cancel just disable the whole thing
+        bbx.rejected.connect(lambda: self.setDisabled(True))
+        # on save, validate and store
+        bbx.accepted.connect(self._save_metadata)
+        self.__bbx = bbx
+        editor_layout.addWidget(bbx)
 
     def set_path(self, path: Path):
-        pass
+        self.__path = path
+        self._load_metadata()
+
+    def _reset(self):
+        # take care of cleaning up the underlying items
+        field_items = [
+            self.__field_form.itemAt(row, QFormLayout.LabelRole).widget()
+            # start after header
+            for row in range(1, self.__field_form.rowCount())
+        ]
+        for fi in field_items:
+            self._discard_item(fi)
+        self.__bbx.button(QDialogButtonBox.Save).setDisabled(True)
+
+    def _load_metadata(self):
+        res = _run_annex_metadata(self.__path)
+        # just one record
+        assert isinstance(res, dict)
+        self._set_metadata_from_annexjson(res)
+
+    def _set_metadata_from_annexjson(self, data):
+        last_changed_marker = '-lastchanged'
+        # clean slate
+        self._reset()
+        fields = data['fields']
+        field_widgets = {}
+        last_changed = {}
+        for f in sorted(fields):
+            if f == 'lastchanged':
+                # we have no use for the overall timestamp ATM
+                continue
+            if f.endswith(last_changed_marker):
+                # comes as an array of length 1
+                last_changed[f[:-1 * len(last_changed_marker)]] = fields[f][0]
+                continue
+
+            fw, fv_layout = self._add_field()
+            fw.set_value(f)
+            for v in fields[f]:
+                fv = self._add_field_value(fw, fv_layout)
+                fv.set_value(v)
+            self._add_field_value_add_pb(fw, fv_layout)
+            field_widgets[f] = fw
+
+        for f, fw in field_widgets.items():
+            fw.set_state(
+                QStyle.SP_FileDialogInfoView,
+                f'Last changed: {last_changed.get(f, "")}'
+            )
+        self.enable_save()
+
+    def _validate(self):
+        warn_pm = QStyle.SP_MessageBoxWarning
+        valid = True
+
+        def _invalid(item, msg):
+            item.set_state(warn_pm, msg)
+            return False
+
+        def _valid(item):
+            item.set_state()
+
+        data = {}
+        fn_validator = ItemWidget._validators[self]
+        for fni in ItemWidget._field_tracker[self]:
+            # first check field name value, we don't accept invalid of empty
+            if fn_validator.validate(fni.value, 0) != QValidator.Acceptable:
+                valid = _invalid(
+                    fni, 'Invalid value, set valid value or discard')
+            else:
+                _valid(fni)
+            # now all values, may be empty to delete whole field
+            fv_validator = ItemWidget._validators[fni]
+            values = set()
+            for fvi in ItemWidget._field_tracker[fni]:
+                if fv_validator.validate(fvi.value, 0) != QValidator.Acceptable:
+                    valid = _invalid(
+                        fvi, 'Invalid value, set valid value or discard')
+                else:
+                    _valid(fvi)
+                    values.add(fvi.value)
+            data[fni.value] = list(values)
+        return data, valid
+
+    def enable_save(self):
+        self.__bbx.button(QDialogButtonBox.Save).setEnabled(True)
+
+    def _save_metadata(self):
+        data, valid = self._validate()
+        if not valid:
+            self.__bbx.button(QDialogButtonBox.Save).setDisabled(True)
+            return
+        res = _run_annex_metadata(self.__path, data)
+        # just one record
+        assert isinstance(res, dict)
+        self._set_metadata_from_annexjson(res)
+
+    def _add_field(self):
+        # field name edit, make the editor itself the parent
+        # the items will group themselves by parent to validate as a set
+        # within a group
+        fn = ItemWidget(self, self, self)
+        # layout to contain all field
+        flow_layout = FlowLayout()
+        flow_layout.setContentsMargins(0, 0, 0, 0)
+        self.__field_form.addRow(fn, flow_layout)
+        return fn, flow_layout
+
+    def _on_addfield_clicked(self):
+        fn, layout = self._add_field()
+        # use the field name widget as a parent for the field value widgets
+        # by that they will group themselves to act like a set during
+        # validation
+        self._add_field_value(fn, layout)
+        self._add_field_value_add_pb(fn, layout)
+
+    def _on_add_field_value_clicked(self, group_id, replace=None):
+        row = self._find_form_row_by_name_widget(group_id)
+        # the flow layout for all value widgets
+        layout = self.__field_form.itemAt(row, QFormLayout.FieldRole)
+        if replace is not None:
+            replace.close()
+            layout.removeWidget(replace)
+            del replace
+        self._add_field_value(group_id, layout)
+        self._add_field_value_add_pb(group_id, layout)
+
+    def _add_field_value(self, group_id, layout):
+        # field value edit
+        fv = ItemWidget(group_id, self, self)
+        layout.addWidget(fv)
+        return fv
+
+    def _add_field_value_add_pb(self, group_id, layout):
+        # '+' button to add a new value
+        pb = QPushButton(self)
+        pb.setText('+')
+        pb.clicked.connect(lambda: self._on_add_field_value_clicked(
+            group_id, replace=pb))
+        layout.addWidget(pb)
+        self.enable_save()
+
+    def _find_form_row_by_name_widget(self, widget):
+        # start searching after header row
+        for row in range(1, self.__field_form.rowCount()):
+            label_at_row = self.__field_form.itemAt(
+                row, QFormLayout.LabelRole).widget()
+            if widget == label_at_row:
+                return row
+        raise ValueError(
+            'Given widget does not correspond to field name widget')
+
+    def _discard_item(self, item):
+        self.enable_save()
+        if isinstance(item.group_id, AnnexMetadataEditor):
+            # the main editor is the group -> field name widget
+            row = self._find_form_row_by_name_widget(item)
+            layout = self.__field_form.itemAt(row, QFormLayout.FieldRole)
+            i = layout.takeAt(0)
+            while i:
+                i.widget().close()
+                i = layout.takeAt(0)
+            i = self.__field_form.itemAt(row, QFormLayout.LabelRole).widget()
+            i.close()
+            self.__field_form.removeRow(row)
+        else:
+            # -> field value widget
+            row = self._find_form_row_by_name_widget(item.group_id)
+            layout = self.__field_form.itemAt(row, QFormLayout.FieldRole)
+            item.close()
+            layout.removeWidget(item)
+
+
+class ItemWidget(QWidget):
+    # track fields for a particular path across all class
+    # instances
+    _field_tracker = dict()
+    _validators = dict()
+
+    def __init__(self,
+                 group_id: Any,
+                 editor: AnnexMetadataEditor,
+                 parent: QWidget):
+        super().__init__(parent)
+        self.__annex_metadata_editor = editor
+        self.__group_id = group_id
+        if group_id not in ItemWidget._field_tracker:
+            items_widgets = set()
+            ItemWidget._field_tracker[group_id] = items_widgets
+            ItemWidget._validators[group_id] = SetFieldNameValidator(group_id, editor)
+        # register item in the group of its parent
+        items = self._field_tracker[group_id]
+        items.add(self)
+
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+        db = QPushButton(self)
+        db.setIcon(self.style().standardIcon(QStyle.SP_DialogDiscardButton))
+        db.clicked.connect(lambda: editor._discard_item(self))
+        layout.addWidget(db)
+        edit = QLineEdit(self)
+        edit.setClearButtonEnabled(True)
+        #edit.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        edit.textChanged.connect(self._on_textchanged)
+        edit.editingFinished.connect(self._on_editingfinished)
+        edit.setValidator(ItemWidget._validators[group_id])
+        layout.addWidget(edit)
+        self.__editor = edit
+        state = QLabel(self)
+        self.__state_label = state
+        layout.addWidget(state)
+
+    def closeEvent(self, *args, **kwargs):
+        # unregister this item from its parent group
+        if self.__group_id in self._field_tracker:
+            self._field_tracker[self.__group_id].discard(self)
+        # if this item is itself a group_id, remove entire group
+        self._field_tracker.pop(self, None)
+        self._validators.pop(self, None)
+        # normal handling
+        super().closeEvent(*args, **kwargs)
+
+    @property
+    def group_id(self):
+        return self.__group_id
+
+    @property
+    def value(self):
+        return self.__editor.text()
+
+    def _on_textchanged(self):
+        # clear any checkmarks (empty pixmap)
+        self.set_state()
+        self.__annex_metadata_editor.enable_save()
+        # TODO make resize to minimum work
+        return
+        #edit = self.__editor
+        #text = edit.text()
+        #if len(text) < 4:
+        #    text = 'mmmm'
+        #px_width = QFontMetrics(edit.font()).size(
+        #    Qt.TextSingleLine, text).width()
+        #edit.setFixedWidth(px_width)
+
+    def _on_editingfinished(self):
+        # put a little checkmark behind the edit as an indicator that
+        # the current field name is OK
+        self.set_state(QStyle.SP_DialogApplyButton)
+
+    def set_state(self, stdpixmap=None, tooltip=None):
+        if stdpixmap is None:
+            pixmap = QPixmap(0, 0)
+        else:
+            pixmap = self.style().standardPixmap(stdpixmap)
+        self.__state_label.setPixmap(pixmap)
+
+        if not tooltip:
+            tooltip = ''
+        self.__state_label.setToolTip(tooltip)
+
+    def set_value(self, value):
+        self.__editor.setText(value)
+
+
+class SetFieldNameValidator(QValidator):
+    def __init__(self, group_id: Any, parent: QWidget):
+        super().__init__(parent)
+        self.__group_id = group_id
+
+    def validate(self, input: str, pos: int):
+        # we cannot ever invalidate, because a user could always
+        # enter another char to make it right
+        if not input:
+            return QValidator.Intermediate
+
+        # check all items from this group
+        matching_items = sum(
+            input == i.value
+            for i in ItemWidget._field_tracker[self.__group_id]
+        )
+        if matching_items > 1:
+            return QValidator.Intermediate
+        else:
+            return QValidator.Acceptable
+
+
+def _run_annex_metadata(path, data=None):
+    from datalad.runner import (
+        GitRunner,
+        StdOutCapture,
+    )
+    from datalad.utils import get_dataset_root
+    import json
+    runner = GitRunner()
+    cmd = ['git', 'annex', 'metadata', '--json', '--batch']
+    dsroot = get_dataset_root(path)
+    j = {
+        'file': str(path.relative_to(dsroot)),
+    }
+    if data:
+        j['fields'] = data
+    out = runner.run(
+        cmd,
+        cwd=str(dsroot),
+        stdin=f'{json.dumps(j)}\n'.encode('utf-8'),
+        protocol=StdOutCapture,
+    )
+    res = json.loads(out['stdout'])
+    return res

--- a/datalad_gooey/annex_metadata.py
+++ b/datalad_gooey/annex_metadata.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QLabel,
+    QVBoxLayout,
+)
+
+from .metadata_editor_base import MetadataEditor
+
+
+class AnnexMetadataEditor(MetadataEditor):
+    def __init__(self, parent):
+        super().__init__(parent)
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+        label = QLabel('Annex!')
+        layout.addWidget(label)
+
+    def set_path(self, path: Path):
+        pass

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -351,15 +351,15 @@ class GooeyApp(QObject):
         """Private slot to pull up a metadata editor"""
         action = self.sender()
         if action is not None:
-            path, metadata_type = action.data()
-        if path is None or metadata_type is None:
+            path, editor_type = action.data()
+        if path is None or editor_type is None:
             raise ValueError(
                 'MetadataWidget.setup_for() called without a path or metadata '
-                'type specifier')
+                'editor type')
 
         tab = self.get_widget('metadataTab')
         metadata_widget = self.get_widget('metadataTabWidget')
-        metadata_widget.setup_for(path=path, metadata_type=metadata_type)
+        metadata_widget.setup_for(path=path, editor_type=editor_type)
         # open the metadata tab
         self.get_widget('contextTabs').setCurrentWidget(tab)
 

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -53,6 +53,7 @@ from .fsbrowser import GooeyFilesystemBrowser
 from .resource_provider import gooey_resources
 from . import utility_actions as ua
 from . import credentials as cred
+from .metadata_widget import MetadataWidget
 
 lgr = logging.getLogger('datalad.ext.gooey.app')
 
@@ -65,6 +66,7 @@ class GooeyQMainWindow(QMainWindow):
         'contextTabs': QTabWidget,
         'cmdTab': QWidget,
         'metadataTab': QWidget,
+        'metadataTabWidget': MetadataWidget,
         'helpBrowser': QTextBrowser,
         'propertyBrowser': QTextBrowser,
         'fsBrowser': QTreeWidget,
@@ -157,7 +159,7 @@ class GooeyApp(QObject):
 
         self._dlapi = None
         self._main_window : GooeyQMainWindow = \
-            load_ui('main_window', custom_widgets=[GooeyQMainWindow])
+            load_ui('main_window', custom_widgets=[GooeyQMainWindow, MetadataWidget])
         self._cmdexec = GooeyDataladCmdExec()
         self._cmdui = GooeyDataladCmdUI(self, self.get_widget('cmdTab'))
 
@@ -344,6 +346,22 @@ class GooeyApp(QObject):
     @property
     def rootpath(self):
         return self._path
+
+    def _edit_metadata(self):
+        """Private slot to pull up a metadata editor"""
+        action = self.sender()
+        if action is not None:
+            path, metadata_type = action.data()
+        if path is None or metadata_type is None:
+            raise ValueError(
+                'MetadataWidget.setup_for() called without a path or metadata '
+                'type specifier')
+
+        tab = self.get_widget('metadataTab')
+        metadata_widget = self.get_widget('metadataTabWidget')
+        metadata_widget.setup_for(path=path, metadata_type=metadata_type)
+        # open the metadata tab
+        self.get_widget('contextTabs').setCurrentWidget(tab)
 
     def _populate_datalad_menu(self):
         """Private slot to populate connected QMenus with dataset actions"""

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -64,9 +64,11 @@ class GooeyQMainWindow(QMainWindow):
     # up widget (e.g. to connect their signals/slots)
     _widgets = {
         'contextTabs': QTabWidget,
+        'consoleTabs': QTabWidget,
         'cmdTab': QWidget,
         'metadataTab': QWidget,
         'metadataTabWidget': MetadataWidget,
+        'helpTab': QWidget,
         'helpBrowser': QTextBrowser,
         'propertyBrowser': QTextBrowser,
         'fsBrowser': QTreeWidget,
@@ -360,8 +362,16 @@ class GooeyApp(QObject):
         tab = self.get_widget('metadataTab')
         metadata_widget = self.get_widget('metadataTabWidget')
         metadata_widget.setup_for(path=path, editor_type=editor_type)
+        self.show_help(metadata_widget.get_doc_text())
         # open the metadata tab
         self.get_widget('contextTabs').setCurrentWidget(tab)
+
+    def show_help(self, text: str):
+        hbrowser = self.get_widget('helpBrowser')
+        hbrowser.setPlainText(text)
+        # bring help tab to the front
+        self.get_widget('consoleTabs').setCurrentWidget(
+            self.get_widget('helpTab'))
 
     def _populate_datalad_menu(self):
         """Private slot to populate connected QMenus with dataset actions"""

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -66,6 +66,7 @@ class GooeyQMainWindow(QMainWindow):
         'contextTabs': QTabWidget,
         'consoleTabs': QTabWidget,
         'cmdTab': QWidget,
+        'commandLogTab': QWidget,
         'metadataTab': QWidget,
         'metadataTabWidget': MetadataWidget,
         'helpTab': QWidget,
@@ -241,6 +242,10 @@ class GooeyApp(QObject):
         self._connect_menu_view(self.get_widget('menuView'))
 
     def _setup_ongoing_cmdexec(self, thread_id, cmdname, cmdargs, exec_params):
+        # bring console tab to the front
+        self.get_widget('consoleTabs').setCurrentWidget(
+            self.get_widget('commandLogTab'))
+
         self.get_widget('statusbar').showMessage(f'Started `{cmdname}`')
         self.main_window.setCursor(QCursor(Qt.BusyCursor))
         # and give a persistent visual indication of what exactly is happening

--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -64,6 +64,7 @@ class GooeyQMainWindow(QMainWindow):
     _widgets = {
         'contextTabs': QTabWidget,
         'cmdTab': QWidget,
+        'metadataTab': QWidget,
         'helpBrowser': QTextBrowser,
         'propertyBrowser': QTextBrowser,
         'fsBrowser': QTreeWidget,

--- a/datalad_gooey/dataladcmd_ui.py
+++ b/datalad_gooey/dataladcmd_ui.py
@@ -205,14 +205,10 @@ class GooeyDataladCmdUI(QObject):
         # get the matching callable from the DataLad API
         cmd = getattr(dlapi, cmdname)
         cmd_cls = get_wrapped_class(cmd)
-        hbrowser = self._app.get_widget('helpBrowser')
         # TODO we could use the sphinx RST parser to convert the docstring
-        # into html and do
-        #hbrowser.setHtml()
+        # into html and do .setHtml()
         # but it would have to be the sphinx one, plain docutils is not
         # enough.
         # waiting to be in the right mood for diving into the twisted world
         # of sphinx again
-        hbrowser.setPlainText(
-            format_cmd_docs(cmd_cls.__doc__)
-        )
+        self._app.show_help(format_cmd_docs(cmd_cls.__doc__))

--- a/datalad_gooey/flowlayout.py
+++ b/datalad_gooey/flowlayout.py
@@ -1,0 +1,108 @@
+"""PySide6 port of flowlayout example from Qt v6.x
+
+Licensed under the terms of the GNU Free Documentation License version 1.3
+(https://www.gnu.org/licenses/fdl.html) as published by the Free Software
+Foundation
+"""
+
+from PySide6.QtCore import (
+    Qt,
+    QMargins,
+    QPoint,
+    QRect,
+    QSize,
+)
+from PySide6.QtWidgets import (
+    QLayout,
+    QSizePolicy,
+)
+
+
+class FlowLayout(QLayout):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        if parent is not None:
+            self.setContentsMargins(QMargins(0, 0, 0, 0))
+
+        self._item_list = []
+
+    def __del__(self):
+        item = self.takeAt(0)
+        while item:
+            item = self.takeAt(0)
+
+    def addItem(self, item):
+        self._item_list.append(item)
+
+    def count(self):
+        return len(self._item_list)
+
+    def itemAt(self, index):
+        if 0 <= index < len(self._item_list):
+            return self._item_list[index]
+
+        return None
+
+    def takeAt(self, index):
+        if 0 <= index < len(self._item_list):
+            return self._item_list.pop(index)
+
+        return None
+
+    def expandingDirections(self):
+        return Qt.Orientation(0)
+
+    def hasHeightForWidth(self):
+        return True
+
+    def heightForWidth(self, width):
+        height = self._do_layout(QRect(0, 0, width, 0), True)
+        return height
+
+    def setGeometry(self, rect):
+        super(FlowLayout, self).setGeometry(rect)
+        self._do_layout(rect, False)
+
+    def sizeHint(self):
+        return self.minimumSize()
+
+    def minimumSize(self):
+        size = QSize()
+
+        for item in self._item_list:
+            size = size.expandedTo(item.minimumSize())
+
+        size += QSize(2 * self.contentsMargins().top(), 2 * self.contentsMargins().top())
+        return size
+
+    def _do_layout(self, rect, test_only):
+        x = rect.x()
+        y = rect.y()
+        line_height = 0
+        spacing = self.spacing()
+
+        for item in self._item_list:
+            style = item.widget().style()
+            layout_spacing_x = style.layoutSpacing(
+                QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Horizontal
+            )
+            layout_spacing_y = style.layoutSpacing(
+                QSizePolicy.PushButton, QSizePolicy.PushButton, Qt.Vertical
+            )
+            space_x = spacing + layout_spacing_x
+            space_y = spacing + layout_spacing_y
+            next_x = x + item.sizeHint().width() + space_x
+            if next_x - space_x > rect.right() and line_height > 0:
+                x = rect.x()
+                y = y + line_height + space_y
+                next_x = x + item.sizeHint().width() + space_x
+                line_height = 0
+
+            if not test_only:
+                item.setGeometry(QRect(QPoint(x, y), item.sizeHint()))
+
+            x = next_x
+            line_height = max(line_height, item.sizeHint().height())
+
+        return y + line_height - rect.y()

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -483,8 +483,9 @@ class GooeyFilesystemBrowser(QObject):
             context.addAction(setbase)
 
         if path_type == 'annexed-file':
+            from .annex_metadata import AnnexMetadataEditor
             meta = QAction('&Metadata...', context)
-            meta.setData((ipath, 'git-annex'))
+            meta.setData((ipath, AnnexMetadataEditor))
             meta.triggered.connect(self._app._edit_metadata)
             context.addAction(meta)
 

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -482,6 +482,12 @@ class GooeyFilesystemBrowser(QObject):
             setbase.triggered.connect(self._app._set_root_path)
             context.addAction(setbase)
 
+        if path_type == 'annexed-file':
+            meta = QAction('&Metadata...', context)
+            meta.setData((ipath, 'git-annex'))
+            meta.triggered.connect(self._app._edit_metadata)
+            context.addAction(meta)
+
         if item == self._root_item:
             # for now this is the same as resetting the base to the same
             # root -- but later it could be more clever

--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -17,6 +17,7 @@ from PySide6.QtWidgets import (
     QMenu,
     QTreeWidget,
     QTreeWidgetItem,
+    QWidget,
 )
 
 from datalad.interface.base import Interface
@@ -452,7 +453,6 @@ class GooeyFilesystemBrowser(QObject):
             else:
                 pbrowser.setText(f'No information on {ipath}')
 
-
     def _custom_context_menu(self, onpoint):
         """Present a context menu for the item click in the directory browser
         """
@@ -470,47 +470,11 @@ class GooeyFilesystemBrowser(QObject):
             # to happen)
             return
         ipath = item.pathobj
-        cmdkwargs = dict()
         context = QMenu(parent=self._tree)
 
-        def _check_add_api_submenu(title, api):
-            if not api:
-                return
-            submenu = context.addMenu(title)
-            add_cmd_actions_to_menu(
-                self._tree, self._app._cmdui.configure,
-                api,
-                submenu,
-                cmdkwargs,
-            )
-
-        if path_type == 'dataset':
-            cmdkwargs['dataset'] = ipath
-            from .active_suite import dataset_api
-            _check_add_api_submenu('Dataset commands', dataset_api)
-        elif path_type == 'directory':
-            dsroot = get_dataset_root(ipath)
-            # path the directory path to the command's `path` argument
-            cmdkwargs['path'] = ipath
-            if dsroot:
-                # also pass dsroot
-                cmdkwargs['dataset'] = dsroot
-                from .active_suite import directory_in_ds_api as cmdapi
-            else:
-                from .active_suite import directory_api as cmdapi
-            _check_add_api_submenu('Directory commands', cmdapi)
-        elif path_type in ('file', 'symlink', 'annexed-file'):
-            dsroot = get_dataset_root(ipath)
-            cmdkwargs['path'] = ipath
-            if dsroot:
-                cmdkwargs['dataset'] = dsroot
-                if path_type == 'annexed-file':
-                    from .active_suite import annexed_file_api as cmdapi
-                else:
-                    from .active_suite import file_in_ds_api as cmdapi
-            else:
-                from .active_suite import file_api as cmdapi
-            _check_add_api_submenu('File commands', cmdapi)
+        # test for and populate with select command actions matching this path
+        _populate_context_cmds(
+            context, path_type, ipath, self._tree, self._app._cmdui.configure)
 
         if path_type in ('directory', 'dataset'):
             setbase = QAction('Set &base directory here', context)
@@ -529,3 +493,52 @@ class GooeyFilesystemBrowser(QObject):
         if not context.isEmpty():
             # present the menu at the clicked point
             context.exec(self._tree.viewport().mapToGlobal(onpoint))
+
+
+def _populate_context_cmds(
+        context: QMenu,
+        path_type: str,
+        path: Path,
+        parent: QWidget,
+        receiver: callable):
+
+    cmdkwargs = dict()
+
+    def _check_add_api_submenu(title, api):
+        if not api:
+            return
+        submenu = context.addMenu(title)
+        add_cmd_actions_to_menu(
+            parent, receiver,
+            api,
+            submenu,
+            cmdkwargs,
+        )
+
+    if path_type == 'dataset':
+        cmdkwargs['dataset'] = path
+        from .active_suite import dataset_api
+        _check_add_api_submenu('Dataset commands', dataset_api)
+    elif path_type == 'directory':
+        dsroot = get_dataset_root(path)
+        # path the directory path to the command's `path` argument
+        cmdkwargs['path'] = path
+        if dsroot:
+            # also pass dsroot
+            cmdkwargs['dataset'] = dsroot
+            from .active_suite import directory_in_ds_api as cmdapi
+        else:
+            from .active_suite import directory_api as cmdapi
+        _check_add_api_submenu('Directory commands', cmdapi)
+    elif path_type in ('file', 'symlink', 'annexed-file'):
+        dsroot = get_dataset_root(path)
+        cmdkwargs['path'] = path
+        if dsroot:
+            cmdkwargs['dataset'] = dsroot
+            if path_type == 'annexed-file':
+                from .active_suite import annexed_file_api as cmdapi
+            else:
+                from .active_suite import file_in_ds_api as cmdapi
+        else:
+            from .active_suite import file_api as cmdapi
+        _check_add_api_submenu('File commands', cmdapi)

--- a/datalad_gooey/metadata_editor_base.py
+++ b/datalad_gooey/metadata_editor_base.py
@@ -5,6 +5,8 @@ from PySide6.QtWidgets import (
     QLabel,
 )
 
+from .api_utils import format_cmd_docs
+
 
 class MetadataEditor(QWidget):
     def __init__(self, parent):
@@ -19,6 +21,9 @@ class MetadataEditor(QWidget):
         if self.__title_widget is None:
             self.__title_widget = QLabel(self._widget_title)
         return self.__title_widget
+
+    def get_doc_text(self):
+        return format_cmd_docs(self.__doc__)
 
 
 class NoMetadataEditor(MetadataEditor):

--- a/datalad_gooey/metadata_editor_base.py
+++ b/datalad_gooey/metadata_editor_base.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from PySide6.QtWidgets import QWidget
+
+
+class MetadataEditor(QWidget):
+    def __init__(self, parent):
+        super().__init__(parent)
+
+    def set_path(self, path: Path):
+        raise NotImplementedError

--- a/datalad_gooey/metadata_editor_base.py
+++ b/datalad_gooey/metadata_editor_base.py
@@ -1,11 +1,25 @@
 from pathlib import Path
 
-from PySide6.QtWidgets import QWidget
+from PySide6.QtWidgets import (
+    QWidget,
+    QLabel,
+)
 
 
 class MetadataEditor(QWidget):
     def __init__(self, parent):
         super().__init__(parent)
 
+        self.__title_widget = None
+
     def set_path(self, path: Path):
         raise NotImplementedError
+
+    def get_title_widget(self):
+        if self.__title_widget is None:
+            self.__title_widget = QLabel(self._widget_title)
+        return self.__title_widget
+
+
+class NoMetadataEditor(MetadataEditor):
+    _widget_title = 'Metadata'

--- a/datalad_gooey/metadata_widget.py
+++ b/datalad_gooey/metadata_widget.py
@@ -21,8 +21,10 @@ class MetadataWidget(QWidget):
     def __init__(self, parent):
         super().__init__(parent)
         layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
         # title
+        # TODO request a title from the metadata editor
         label = QLabel('META!')
         layout.addWidget(label)
         # path and metadata-type selector
@@ -67,6 +69,7 @@ class MetadataWidget(QWidget):
         self.__path_edit.setText(str(path))
 
         editor = editor_type(self)
+        editor.set_path(path)
         # locate any previous editor widget (second to last in layout)
         prev_editor_widget = self.layout().itemAt(
             self.layout().count() - 2).widget()

--- a/datalad_gooey/metadata_widget.py
+++ b/datalad_gooey/metadata_widget.py
@@ -77,3 +77,6 @@ class MetadataWidget(QWidget):
             del old_layout_item
         # lastly replace old editor in full and let garbage collection RIP it
         self.__editor = editor
+
+    def get_doc_text(self):
+        return self.__editor.get_doc_text()

--- a/datalad_gooey/metadata_widget.py
+++ b/datalad_gooey/metadata_widget.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+from PySide6.QtWidgets import (
+    QWidget,
+    QLabel,
+    QVBoxLayout,
+    QHBoxLayout,
+    QComboBox,
+    QLineEdit,
+)
+
+
+class MetadataWidget(QWidget):
+    """Generic handler for all metadata-type editors/visualizers
+
+    This Widget occupies the "Metadata" tab in the app. It main method
+    is the slot `setup_for()`, which triggers the respective editor
+    implementation to be loaded and initialized with metadata for the
+    respective path.
+    """
+    def __init__(self, parent):
+        super().__init__(parent)
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+        # title
+        label = QLabel('META!')
+        layout.addWidget(label)
+        # path and metadata-type selector
+        slayout = QHBoxLayout()
+        layout.addLayout(slayout)
+        slayout.addWidget(QLabel("Path"))
+        path_edit = QLineEdit(self)
+        # for now
+        path_edit.setDisabled(True)
+        self.__path_edit = path_edit
+        slayout.addWidget(path_edit)
+        slayout.addStretch()
+        slayout.addWidget(QLabel("Type"))
+        md_select = QComboBox(self)
+        md_select.addItems(['git-annex'])
+        # for now
+        md_select.setDisabled(True)
+        self.__metadatatype_select = md_select
+        slayout.addWidget(md_select)
+        # eventual metadata-editor
+        layout.addWidget(QLabel("Select path and metadata type for editing"))
+        # spacer (in case of a small editor
+        layout.addStretch()
+
+    def setup_for(self, path: Path = None, metadata_type: str = None):
+        if path is None or metadata_type is None:
+            action = self.sender()
+            if action is not None:
+                path, metadata_type = action.data()
+        if path is None or metadata_type is None:
+            raise ValueError(
+                'MetadataWidget.setup_for() called without a path or metadata '
+                'type specifier')
+
+        if metadata_type == 'git-annex':
+            from .annex_metadata import AnnexMetadataEditor
+            editor_type = AnnexMetadataEditor
+        else:
+            raise ValueError(f'Unsupported metadata type {metadata_type}')
+
+        self.__metadatatype_select.setCurrentText(metadata_type)
+        self.__path_edit.setText(str(path))
+
+        editor = editor_type(self)
+        # locate any previous editor widget (second to last in layout)
+        prev_editor_widget = self.layout().itemAt(
+            self.layout().count() - 2).widget()
+        # and replace with the new one
+        old_layout_item = self.layout().replaceWidget(
+            prev_editor_widget,
+            editor,
+        )
+        # gracefully retire the previous editor
+        prev_editor_widget.close()
+        del old_layout_item
+        del prev_editor_widget
+        # show the new one
+        editor.show()

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -113,6 +113,11 @@
          <attribute name="title">
           <string>Metadata</string>
          </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="MetadataWidget" name="metadataTabWidget" native="true"/>
+          </item>
+         </layout>
         </widget>
         <widget class="QWidget" name="propertiesTab">
          <attribute name="title">
@@ -379,6 +384,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MetadataWidget</class>
+   <extends>QWidget</extends>
+   <header>datalad_gooey.metadata_widget</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -115,7 +115,26 @@
          </attribute>
          <layout class="QVBoxLayout" name="verticalLayout_5">
           <item>
-           <widget class="MetadataWidget" name="metadataTabWidget" native="true"/>
+           <widget class="QScrollArea" name="scrollArea">
+            <property name="widgetResizable">
+             <bool>true</bool>
+            </property>
+            <widget class="QWidget" name="scrollAreaWidgetContents">
+             <property name="geometry">
+              <rect>
+               <x>0</x>
+               <y>0</y>
+               <width>428</width>
+               <height>263</height>
+              </rect>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_6">
+              <item>
+               <widget class="MetadataWidget" name="metadataTabWidget" native="true"/>
+              </item>
+             </layout>
+            </widget>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -109,6 +109,11 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="metadataTab">
+         <attribute name="title">
+          <string>Metadata</string>
+         </attribute>
+        </widget>
         <widget class="QWidget" name="propertiesTab">
          <attribute name="title">
           <string>Properties</string>

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -253,7 +253,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="tabHelp">
+       <widget class="QWidget" name="helpTab">
         <attribute name="title">
          <string>Help</string>
         </attribute>

--- a/datalad_gooey/resources/ui/main_window.ui
+++ b/datalad_gooey/resources/ui/main_window.ui
@@ -154,7 +154,7 @@
        <property name="currentIndex">
         <number>0</number>
        </property>
-       <widget class="QWidget" name="tabCommandLog">
+       <widget class="QWidget" name="commandLogTab">
         <attribute name="title">
          <string>Command log</string>
         </attribute>


### PR DESCRIPTION
This brings a new "Metadata" context tab, and an editor widget for git-annex metadata (which can load/save from/to the repo).

Importantly, this is not done in a generic fashion using a CLI implementation, but GUI-native. Main reason is lack of ability of the author.

- Closes #280 
- Closes #266

https://user-images.githubusercontent.com/136479/195285767-7ae675f5-51b9-40cb-8048-f4c67b162404.mp4

TODO
- [x] annex metadata field names (as opposed to values) have stricter requirements. Validate those too.
- [x] make fields loaded from an existing metadata record non-discardable. otherwise users will be confused that their records remain