### PR TITLE
Build windows installer from last release

### DIFF
--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -1,19 +1,10 @@
-# Deploy manually
+# Workflow to build installer on windows. Workflow runs when manually
+# triggered using the UI or API.
 
-name: Build Windows Installer
+name: Build Windows Installer for the Latest Release
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
-on:
-  workflow_dispatch:
-    inputs:
-      revision:
-        description: 'Git revision (reference, branch, or tag) of datalad-gooey which should be built'
-        required: true
-        default: 'main'
-        type: string
+on: workflow_dispatch
 
-# Workflow to build installer on windows
 jobs:
 
   build-installer:
@@ -22,40 +13,33 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Get latest release info
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Checkout revision to build repo
-        uses: actions/checkout@v2
+      - name: Checkout released code
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          ref: ${{ steps.get_release.outputs.tag_name }}
 
       - name: Build installer
         run: |
           cd tools\installer_building
-          $build_out = .\build_windows_installer.ps1 ${{ inputs.revision }}
+          $build_out = .\build_windows_installer.ps1 ${{ steps.get_release.outputs.tag_name }}
           $build_time = Get-Date -format yyyyMMddHHmm
           $build_branch = echo $build_out|Select-String -Pattern "installed_version:"
           $build_branch = $build_branch.ToString().Substring(19)
-          echo "build_id=$build_time-$build_branch" >> ${env:GITHUB_ENV}
+          echo "build_id=$build_branch" >> ${env:GITHUB_ENV}
         shell: powershell
 
-      - name: Create installer release
-        uses: actions/create-release@v1
-        id: create_release
-        with:
-          draft: false
-          prerelease: false
-          release_name: windows ${{ env.build_id }}
-          tag_name: windows-${{ env.build_id }}
-          body_path: tools\installer_building\CHANGELOG.md
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-      
       - name: Upload installer artifact
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: tools\installer_building\datalad-gooey-installer-amd64.exe
-          asset_name: datalad-gooey-installer-amd64.exe
+          asset_name: datalad-gooey-installer-${{ steps.get_release.outputs.tag_name }}-amd64.exe
           asset_content_type: application/vnd.microsoft.portable-executable

--- a/.github/workflows/build_windows_installer.yml
+++ b/.github/workflows/build_windows_installer.yml
@@ -19,10 +19,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Checkout released code
+      - name: Checkout repository with build specs
         uses: actions/checkout@v3
-        with:
-          ref: ${{ steps.get_release.outputs.tag_name }}
 
       - name: Build installer
         run: |


### PR DESCRIPTION
This PR modifies the build windows installer-action to always build a windows installer from the latest release of `datalad-gooey`.

This prevents problems with releases and tags that are created for a windows installer that is built from a "random" revision of the code.
