### PR TITLE
WIN: add uninstaller

### DIFF
--- a/tools/installer_building/windows-installer-amd64.nsi
+++ b/tools/installer_building/windows-installer-amd64.nsi
@@ -26,3 +26,8 @@ Section "Datalad-Gooey"
     File /r "sources\datalad.ico"
     CreateShortCut /NoWorkingDir "$DESKTOP\Datalad Gooey.lnk" "$INSTDIR\python39\python" "-m datalad_gooey" "$INSTDIR\datalad.ico"
 SectionEnd
+
+Section "Uninstall"
+    Delete $INSTDIR\Uninst.exe ; delete self
+    RMDir $INSTDIR
+SectionEnd


### PR DESCRIPTION
This adds an uninstall section to the nsi script, following https://nsis.sourceforge.io/Docs/Chapter4.html#UninstallSection. I'm a bit unsure how to best test this - with the way the workflow to build the installer is currently set up, this would need to be merged and then manually triggered.

See #326 for the reasoning.