### PR TITLE
Stop unwatching directories when tree item is collapsed

### DIFF
--- a/datalad_gooey/fsbrowser.py
+++ b/datalad_gooey/fsbrowser.py
@@ -70,7 +70,6 @@ class GooeyFilesystemBrowser(QObject):
         tw.itemExpanded.connect(self._watch_dir)
         # and also populate it with items for contained paths
         tw.itemExpanded.connect(self._populate_item)
-        tw.itemCollapsed.connect(self._unwatch_dir)
         self._fswatcher.directoryChanged.connect(self._inspect_changed_dir)
 
         # items of directories to be annotated, populated by
@@ -348,16 +347,6 @@ class GooeyFilesystemBrowser(QObject):
             # Git operation outcomes. specifically watch the HEADS to catch
             # updates on any branch
             self._fswatcher.addPath(str(path / '.git' / 'refs' / 'heads'))
-
-    # https://github.com/datalad/datalad-gooey/issues/50
-    def _unwatch_dir(self, item):
-        path = str(item.pathobj)
-        lgr.log(
-            9,
-            "GooeyFilesystemBrowser._unwatch_dir(%r) -> %r",
-            path,
-            self._fswatcher.removePath(path),
-        )
 
     def _inspect_changed_dir(self, path: str):
         pathobj = Path(path)


### PR DESCRIPTION
This behavior has a number of issues. It stops monitoring that particular directory, but not any of the subdirectories that might also be watched (although equally invisible).

Moreover, re-expanding such an item will put it back on the watch list, but it will not repopulate the item with any changes that occurred in in the meantime.

Overall, this leads to inconsistencies between FS and tree view.

The original intention was to save on resources for watching. However, even on the most limited systems a few dozens are easily possible. I'd say we tune this whenever we actually hit a use case where this is a problem.

Until then, we never stop watch a directory that we started watching once. `QFileSystemWatcher` is already taking care of automatically unwatching directories that get deleted.

- Closes datalad/datalad-gooey#50