### PR TITLE
Fix ui.question's text + title

### DIFF
--- a/datalad_gooey/datalad_ui.py
+++ b/datalad_gooey/datalad_ui.py
@@ -1,3 +1,4 @@
+import os
 import threading
 from textwrap import wrap
 from types import MappingProxyType
@@ -226,8 +227,10 @@ class GooeyUI(DialogUI):
             # to make sure that our signal is the only one putting an answer in
             # the queue
             self._uibridge.question_asked.emit(MappingProxyType(dict(
-                title=title,
-                text=text,
+                title="Input required",
+                # Note, that ui.question's `title` is meant for the prompting
+                # text:
+                text=title + os.linesep + text,
                 choices=choices,
                 default=default,
                 hidden=hidden,


### PR DESCRIPTION
datalad core's `ui.question` is meant to take the prompting text via `title`. Now that there's a GUI backend this turns out to be a misleading name.
Fix the implementation to use the passed `title` in the label and have constant window title instead.

Not sure about that constant title, though. `Input required` may feel somewhat strange. Happy for other suggestions.

In combination with https://github.com/datalad/datalad-next/pull/113 this is supposed to fix #340 .