### PR TITLE
Absent subdataset handling

### DIFF
--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -37,6 +37,10 @@ class FSBrowserItem(QTreeWidgetItem):
     def datalad_type(self):
         return self.data(1, Qt.EditRole)
 
+    @property
+    def datalad_state(self):
+        return self.data(2, Qt.EditRole)
+
     def set_item_type(self, type_: str, icon: str or None = None):
         prev_type = self.data(1, Qt.EditRole)
         if prev_type == type_:

--- a/datalad_gooey/lsdir.py
+++ b/datalad_gooey/lsdir.py
@@ -84,7 +84,12 @@ class GooeyLsDir(Interface):
                     r['message'] = 'Permissions denied'
                     yield r
                     continue
-                r['type'] = 'dataset' if is_repo else 'directory'
+                if is_repo:
+                    # the dataset must be untracked, or its would not have been
+                    # reported as a 'directory' to begin with
+                    r.update(type='dataset', state='untracked')
+                else:
+                    r.update(type='directory')
             yield r
 
 

--- a/datalad_gooey/param_form_utils.py
+++ b/datalad_gooey/param_form_utils.py
@@ -100,7 +100,8 @@ def populate_form_w_params(
             continue
         if pname in cmd_api_spec.get('exclude_parameters', []):
             continue
-        cmdkwargs_defaults[pname] = pdefault
+        cmdkwargs_defaults[pname] = cmd_api_spec.get(
+            'parameter_default', {}).get(pname, pdefault)
         # populate the layout with widgets for each of them
         # we do not pass Parameter instances further down, but disassemble
         # and homogenize here

--- a/datalad_gooey/simplified_api.py
+++ b/datalad_gooey/simplified_api.py
@@ -201,11 +201,16 @@ api = dict(
             'reckless',
             'source',
         )),
+        parameter_default=dict(
+            # we are no exposing this, hence we must provide a sane default,
+            # which cannot be get everything always, but rather one level
+            # at a time.
+            recursion_limit=1,
+        ),
         parameter_display_names=dict(
             dataset='Get content in dataset at',
             path='Limit to',
-            # 'all' because we have no recursion_limit enabled
-            recursive='Also get all subdatasets',
+            recursive='Also get subdatasets',
             get_data='Get file content',
         ),
         parameter_order=dict(


### PR DESCRIPTION
- proper `state` annotation by `lsdir` and `status-light`
- better context handling in dataset actions on absent subdatasets #336 
- allow API command default overrides #219 
- set default recursion limit (for `get`) in simplified API to `1`

- Closes #336 
- Closes #238 
- Closes #219
