### PR TITLE
More accurate handling of `nargs=*|+`

### DIFF
--- a/datalad_gooey/param_form_utils.py
+++ b/datalad_gooey/param_form_utils.py
@@ -217,14 +217,14 @@ def _get_comprehensive_constraint(
         constraint = EnsureIterableOf(
             list, constraint, min_len=nargs, max_len=nargs)
     elif nargs == '*':
-        # sequence of any length, but always a sequence
-        #constraint = EnsureIterableOf(list, constraint)
-        # XXX yeah, not quite. datalad expects things often to also
-        # work for a single item
-        constraint = EnsureIterableOf(list, constraint)
+        # datalad expects things often/always to also work for a single item
+        constraint = EnsureIterableOf(list, constraint) | constraint
     elif nargs == '+':
-        # sequence of at least 1 item, always a sequence
-        constraint = EnsureIterableOf(list, constraint, min_len=1)
+        # sequence of at least 1 item, always a sequence,
+        # but again datalad expects things often/always to also work for
+        # a single item
+        constraint = EnsureIterableOf(
+            list, constraint, min_len=1) | constraint
     # handling of `default` and `const` would be here
     #elif nargs == '?'
 
@@ -340,6 +340,19 @@ def _get_parameter(
                 if not isinstance(p.get_constraint(), EnsureNone)
             ]
             # we must have some left, or all alternatives were EnsureNone
+            assert len(param_alternatives)
+        # now look for the case where we have an OR combination of a constraint
+        # and the same constraint wrapped into an interable contraint.
+        # in this case we can strip the item-constraint,
+        # because MultiValueWidget can handle that as a special case.
+        for iter_constraint in [
+                c.item_constraint for c in constraint.constraints
+                if isinstance(c, EnsureIterableOf)]:
+            param_alternatives = [
+                p for p in param_alternatives
+                if p.get_constraint() != iter_constraint
+            ]
+            # we must have some left, or mih has a logic error
             assert len(param_alternatives)
         # if only one alternative is left, skip the AlternativesParameter
         # entirely, and go with that one

--- a/datalad_gooey/param_multival.py
+++ b/datalad_gooey/param_multival.py
@@ -60,9 +60,6 @@ class MultiValueParameter(GooeyCommandParameter):
         for val in ensure_list(value):
             wid._add_item(data=val)
 
-    def set_from_spec(self, spec: Dict) -> None:
-        self._item_param.set_from_spec(spec)
-
     def get_spec(self):
         self.input_widget._handle_input()
         # we must override, because we need to handle the cases of list vs


### PR DESCRIPTION
This is a three part change:

(1) parameters with `nargs=*` or `nargs=+` take a sequence of values. However, datalad is (almost?) universally implemented to also accept a single item in such cases. Internally values are fed to `EnsureList()` rather than exposing this fact as a proper constraint. Here we turn such `nargs` settings in an explicit

 `EnsureIterableOf(list, constraint) | constraint`

alternative constrain specification.

(2) The first change makes it necessary to avoid duplicating parameter input widgets in such cases, because `MultiValueWidget` is capable of accepting a single item, making a dedicated single item input for the exact same data type superfluous (and ugly). Here we look for this case when generating input widgets, and we discard the single-item input in favor of the multi-value input.

(3) Both changes combined make it possible for `MultiValueWidget` to stop bypassing a parameter constraint, and actuall "set" values properly, rather then merely showing them in the input widget.

- Closes datalad/datalad-gooey#361