### PR TITLE
Make datalad-command available to datalad_gooey on Windows

### DIFF
--- a/tools/installer_building/build_windows_installer.ps1
+++ b/tools/installer_building/build_windows_installer.ps1
@@ -4,38 +4,86 @@ Param(
     [string]$Revision
 )
 
-$start_dir = Get-Location
+Set-PSDebug -Trace 0
 
-Push-Location $env:TEMP
+$start_dir = Get-Location
+$build_dir = "${env:TEMP}\build-datalad-gooey-installer"
+$sources_dir = "${build_dir}\sources"
+
+
+# -------------------------------------------------------------
+# Clean up old installation building files
+if (Test-Path ${build_dir}) {
+    Remove-Item -Recurse -Force ${build_dir}
+}
+
+New-Item -Path $build_dir -ItemType directory -Force
+New-Item -Path ${sources_dir} -ItemType directory -Force
+
+Push-Location $build_dir
+
+
+# -------------------------------
+# Set up the embedded interpreter
 
 # Download embeddable python version 3.9.13
 Invoke-WebRequest -UseBasicParsing https://www.python.org/ftp/python/3.9.13/python-3.9.13-embed-amd64.zip -OutFile empy-3.9.13-amd64.zip
-New-Item -Path sources -ItemType directory -Force
 
 # Extract the archive
-Expand-Archive empy-3.9.13-amd64.zip sources\python39 -Force
+Expand-Archive empy-3.9.13-amd64.zip ${sources_dir}\python39 -Force
 
 # Adapt the path variable to allow for pip
-'import site' | Out-File -FilePath sources\python39\python39._pth -Append -Encoding utf8
+'import site' | Out-File -FilePath ${sources_dir}\python39\python39._pth -Append -Encoding utf8
 
-# Download pip and execute it
+# Download get-pip and execute it to install pip in the embedded python environment
 Invoke-WebRequest -UseBasicParsing https://bootstrap.pypa.io/get-pip.py -OutFile get-pip.py
-.\sources\python39\python.exe get-pip.py
+Start-Process "${sources_dir}\python39\python.exe" -ArgumentList get-pip.py -Wait
 
-# Use pip to install the latest version of datalad-gooey
-.\sources\python39\python.exe -m pip install "git+https://github.com/datalad/datalad-gooey.git@$Revision"
-$installed_version = .\sources\python39\python.exe -c "import datalad_gooey._version as v; print(v.get_versions()['version'])"
 
-# Copy the icon, git installer, and git-annex installer to "sources" where the script
-# expects them
-Copy-Item $start_dir\resources\datalad.ico .\sources
-Copy-Item $start_dir\resources\dl.py .\sources\python39\dl.py
+#-----------------------------------------------------------------
+# Create a distribution, create a local copy of required wheels
+
+# Get the requested revision of datalad-gooey into the temp directory
+git clone "https://github.com/datalad/datalad-gooey.git"
+Set-Location datalad-gooey
+git fetch origin "$Revision"
+git reset --hard FETCH_HEAD
+
+# Upgrade pip
+python -m pip install pip --upgrade
+
+# Install the builder and build a distribution
+python -m pip install build
+python -m pip install wheel
+New-Item -Path ${sources_dir}\dist -ItemType directory -Force
+python -m build -o ${sources_dir}\dist
+
+# Create `wheelhouse` directory and fetch all dependencies into `wheelhouse`
+New-Item -Path ${sources_dir}\wheelhouse -ItemType directory -Force
+python -m pip wheel -w ${sources_dir}\wheelhouse .
+# Fetch setup tools as well into `wheelhouse`
+python -m pip wheel -w ${sources_dir}\wheelhouse setuptools
+
+
+#--------------------------------------------------------------------------
+# install datalad-gooey using the locally stored wheels and get its version
+python -m pip install --no-index --find-links ${sources_dir}\wheelhouse (Get-Item ${sources_dir}\dist\datalad_gooey-*.whl)
+$fetched_version = python -c "import datalad_gooey._version as v; print(v.get_versions()['version'])"
+
+
+#------------------------------------------------------------------
+# Move data to the location where the installer expects it.
+Set-Location ..
+
+# Copy the icon to "sources" where the NSI script expects it
+Copy-Item $start_dir\resources\datalad.ico ${sources_dir}
+Copy-Item $start_dir\resources\run_gooey.ps1 ${sources_dir}
 
 # Fetch git for windows installer
-Invoke-WebRequest -UseBasicParsing 'https://github.com/git-for-windows/git/releases/download/v2.37.3.windows.1/Git-2.37.3-64-bit.exe' -OutFile .\sources\git-64-bit.exe
+Invoke-WebRequest -UseBasicParsing 'https://github.com/git-for-windows/git/releases/download/v2.37.3.windows.1/Git-2.37.3-64-bit.exe' -OutFile ${sources_dir}\git-64-bit.exe
 
 # Fetch git annex for windows
-Invoke-WebRequest -UseBasicParsing 'https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe' -OutFile .\sources\git-annex-64-bit.exe
+Invoke-WebRequest -UseBasicParsing 'https://downloads.kitenet.net/git-annex/windows/current/git-annex-installer.exe' -OutFile ${sources_dir}\git-annex-64-bit.exe
 
 # Copy the installer script to the temp directory so it can be run in this environment
 # (there may be other ways to ensure correctness of relative paths)
@@ -48,8 +96,8 @@ makensis windows-installer-amd64.nsi
 Move-Item datalad-gooey-installer-amd64.exe $start_dir\datalad-gooey-installer-amd64.exe -Force
 
 # Clean up a little
-Remove-Item sources -Recurse -Force
+#Remove-Item $build_dir -Recurse -Force
 
 Pop-Location
 
-Write-Output "installed_version: $installed_version"
+Write-Output "installed_version: $fetched_version"

--- a/tools/installer_building/resources/run_gooey.ps1
+++ b/tools/installer_building/resources/run_gooey.ps1
@@ -1,0 +1,7 @@
+#! powershell
+
+$ScriptPath = split-path -parent $MyInvocation.MyCommand.Definition
+$env:PATH = "$env:PATH;$ScriptPath"
+
+$env:PYSIDE_DESIGNER_PLUGINS = "."
+Start-Process "$ScriptPath\..\python.exe" -ArgumentList "-m datalad_gooey" -NoNewWindow -Wait

--- a/tools/installer_building/windows-installer-amd64.nsi
+++ b/tools/installer_building/windows-installer-amd64.nsi
@@ -39,5 +39,5 @@ Section "Datalad-Gooey"
     File /r "sources\datalad.ico"
     SetOutPath "$INSTDIR\python39\Scripts"
     File /r "sources\run_gooey.ps1"
-    CreateShortCut /NoWorkingDir "$DESKTOP\Datalad Gooey.lnk" "$INSTDIR\python39\Scripts\run_gooey.ps1" "" "$INSTDIR\datalad.ico"
+    CreateShortCut /NoWorkingDir "$DESKTOP\Datalad Gooey.lnk" "powershell" "$INSTDIR\python39\Scripts\run_gooey.ps1" "$INSTDIR\datalad.ico"
 SectionEnd

--- a/tools/installer_building/windows-installer-amd64.nsi
+++ b/tools/installer_building/windows-installer-amd64.nsi
@@ -2,16 +2,24 @@ Name "Datalad Gooey"
 
 Outfile "datalad-gooey-installer-amd64.exe"
 
+Var GOOEYTEMP
+
+
+Section "Initialize"
+    StrCpy $GOOEYTEMP "$TEMP\datalad-gooey-installer-Wlkfd983e"
+    RMDir /r "$GOOEYTEMP"
+SectionEnd
+
 Section "git"
-    SetOutPath "$TEMP"
+    SetOutPath "$GOOEYTEMP\"
     File /r "sources\git-64-bit.exe"
-    ExecWait "$TEMP\git-64-bit.exe"
+    ExecWait "$GOOEYTEMP\git-64-bit.exe"
 SectionEnd
 
 Section "git-annex"
-    SetOutPath "$TEMP"
+    SetOutPath "$GOOEYTEMP"
     File /r "sources\git-annex-64-bit.exe"
-    ExecWait "$TEMP\git-annex-64-bit.exe"
+    ExecWait "$GOOEYTEMP\git-annex-64-bit.exe"
 SectionEnd
 
 Section "Python 3.9"
@@ -22,7 +30,14 @@ SectionEnd
 
 Section "Datalad-Gooey"
     StrCpy $INSTDIR "$LOCALAPPDATA\datalad.org\datalad-gooey"
+    SetOutPath "$GOOEYTEMP"
+    # TODO: delete wheelhouse and dist
+    File /r "sources\wheelhouse"
+    File /r "sources\dist"
+    ExecWait "powershell $INSTDIR\python39\python -m pip install --no-index --find-links $GOOEYTEMP\wheelhouse (Get-Item $GOOEYTEMP\dist\datalad_gooey*-py3-none-any.whl)"
     SetOutPath "$INSTDIR"
     File /r "sources\datalad.ico"
-    CreateShortCut /NoWorkingDir "$DESKTOP\Datalad Gooey.lnk" "$INSTDIR\python39\python" "-m datalad_gooey" "$INSTDIR\datalad.ico"
+    SetOutPath "$INSTDIR\python39\Scripts"
+    File /r "sources\run_gooey.ps1"
+    CreateShortCut /NoWorkingDir "$DESKTOP\Datalad Gooey.lnk" "$INSTDIR\python39\Scripts\run_gooey.ps1" "" "$INSTDIR\datalad.ico"
 SectionEnd


### PR DESCRIPTION
This PR modifies the installer in such a way that it contains wheels of `datalad_gooey` and all its requirements, and installs `datalad_gooey` and its requirments from these wheels on the target system. That ensures that `datalad.exe` is working properly on the target system.

In addition `datalaf_gooey` is executed in an environment that contains a PATH entry to the newly installed datalad executable