### PR TITLE
Detect to be deleted credential properties, and delete them

### DIFF
--- a/datalad_gooey/credentials.py
+++ b/datalad_gooey/credentials.py
@@ -141,6 +141,13 @@ class GooeyCredentialManager(QObject):
         # datalad's choice of `keyring` makes it impossible to
         # discovery credentials without an external name cue
         props['last-modified'] = datetime.now().isoformat()
+        # now compare the to be set properties with the previously stored ones
+        # (if there are any). any property that is no longer around must be
+        # `None`ed explicitly to trigger deletion
+        prev = self._credman.get(name) or {}
+        for p in prev:
+            if p not in props:
+                props[p] = None
         self._credman.set(
             name,
             # although we edited it, this is not a successful usage


### PR DESCRIPTION
For that we need to compare against the stored credential, and set all vanished properties to `None`.

Closes datalad/datalad-gooey#355