### PR TITLE
Prevent add-operations on `None` and `str`

### DIFF
--- a/datalad_gooey/datalad_ui.py
+++ b/datalad_gooey/datalad_ui.py
@@ -230,7 +230,7 @@ class GooeyUI(DialogUI):
                 title="Input required",
                 # Note, that ui.question's `title` is meant for the prompting
                 # text:
-                text=title + os.linesep + text,
+                text=title or "Input required" + os.linesep + text,
                 choices=choices,
                 default=default,
                 hidden=hidden,


### PR DESCRIPTION
This PR fixes (in a probably sub-optimal way) an exception that occurs at least on Windows, when a token for a GIN-sibling is supposed to be requested. In this case the `title` argument to `GooeyUI.question()` resolves to `None`, leading to an exception in line 233:

```
                    text=title + os.linesep + text,
```

This is a quick fix. Please take it with a grain of salt