### PR TITLE
Annotate symlinks with their targets

### DIFF
--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -22,6 +22,7 @@ class FSBrowserItem(QTreeWidgetItem):
         )
         self.setData(0, FSBrowserItem.PathObjRole, path)
         self._child_lookup = None
+        self._symlink_target = None
 
     def __str__(self):
         return f'FSBrowserItem<{self.pathobj}>'
@@ -63,10 +64,12 @@ class FSBrowserItem(QTreeWidgetItem):
             self.setIcon(2, icon)
 
     def data(self, column: int, role: int):
-        if column == 0 and role in (Qt.DisplayRole, Qt.EditRole):
-            # for now, we do not distinguish the two, maybe never will
-            # but the default implementation also does this, so we match
-            # behavior explicitly until we know better
+        if column == 0 and role == Qt.DisplayRole:
+            if self.datalad_type == 'symlink':
+                return f'{self.pathobj.name} -> {self._symlink_target}'
+            else:
+                return self.pathobj.name
+        elif column == 0 and role == Qt.EditRole:
             return self.pathobj.name
         # fall back on default implementation
         return super().data(column, role)
@@ -135,6 +138,7 @@ class FSBrowserItem(QTreeWidgetItem):
         # - state column for directories
         path_type = res['type']
         self.set_item_type(path_type)
+        self._symlink_target = res.get('symlink_target')
         if res.get('status') == 'error' \
                 and res.get('message') == 'Permissions denied':
             # we cannot get info on it, reflect in UI

--- a/datalad_gooey/lsdir.py
+++ b/datalad_gooey/lsdir.py
@@ -181,10 +181,13 @@ def _lsfiles(path: Path):
         # result), and enable mitigation
         entirely_untracked_dir = p == path
         if not entirely_untracked_dir:
-            yield dict(
+            res = dict(
                 path=str(p),
                 type=props['type'],
             )
+            if props['type'] == 'symlink':
+                res['symlink_target'] = p.readlink()
+            yield res
     if entirely_untracked_dir:
         # fall back on _iterdir() for wholly untracked directories
         yield from _iterdir(path)
@@ -219,6 +222,8 @@ def _iterdir(path: Path):
             path=str(c),
             type=ctype,
         )
+        if ctype == 'symlink':
+            props['symlink_target'] = c.readlink()
         if ctype != 'directory':
             props['state'] = 'untracked'
         yield props

--- a/datalad_gooey/lsdir.py
+++ b/datalad_gooey/lsdir.py
@@ -2,6 +2,7 @@
 
 __docformat__ = 'restructuredtext'
 
+import os
 import stat
 import logging
 from pathlib import Path
@@ -186,7 +187,8 @@ def _lsfiles(path: Path):
                 type=props['type'],
             )
             if props['type'] == 'symlink':
-                res['symlink_target'] = p.readlink()
+                # could be p.readlink() from PY3.9+
+                res['symlink_target'] = os.readlink(p)
             yield res
     if entirely_untracked_dir:
         # fall back on _iterdir() for wholly untracked directories
@@ -223,7 +225,8 @@ def _iterdir(path: Path):
             type=ctype,
         )
         if ctype == 'symlink':
-            props['symlink_target'] = c.readlink()
+            # could be p.readlink() from PY3.9+
+            props['symlink_target'] = os.readlink(c)
         if ctype != 'directory':
             props['state'] = 'untracked'
         yield props


### PR DESCRIPTION
Until now, symlinks were just labeled as such with no indication of their nature.

This change annotates symlinks, both in terms of `lsdir` results and their representation in the FS tree, with their targets.

While a user still cannot "follow" them within the Gooey, they can at least see what is going on.

Before `status` annotation, also annex'ed files are marked up in this fashion, because I see no need to make an expensive special case for that.

Closes datalad/datalad-gooey#23

Double-click event on a symlink pointing to a directory that is also in the tree view will jump to the respective item as current. If there is no target item yet, it will jump to the closest existing one.

New look:
![image](https://user-images.githubusercontent.com/136479/195970906-5efefc78-e062-4370-b44d-5f340cdedd31.png)

Behavior with annexed files:

https://user-images.githubusercontent.com/136479/195970884-7e394a36-1402-4d07-8415-60620d503c8e.mp4


