### PR TITLE
Use datalad-gooey-askpass in Windows

### DIFF
--- a/tools/installer_building/resources/run_gooey.ps1
+++ b/tools/installer_building/resources/run_gooey.ps1
@@ -4,4 +4,6 @@ $ScriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 $env:PATH = "$env:PATH;$ScriptPath"
 
 $env:PYSIDE_DESIGNER_PLUGINS = "."
+$env:DISPLAY = "0:0"
+
 Start-Process "$ScriptPath\..\python.exe" -ArgumentList "-m datalad_gooey" -NoNewWindow -Wait


### PR DESCRIPTION
This PR fixes #371 

The PR enables ash in the windows version of datalad-gooey to interact with users graphically, using `datalad-gooey-askpass`. It sets the environment variable `$env:DISPLAY` in the Windows-specific starting script, which seems to be required to trigger the Windows openssh client to use `$env:SSH_ASKPASS`, even if `$env:SSH_ASKPASS_REQUIRE` is set to `force`.

The change is done in the Windows-specific starting script in oder to not mess with `$DISPLAY` on X11-ish systems.
