### PR TITLE
Use password echo-mode in datalad-gooey-askpass

### DIFF
--- a/datalad_gooey/askpass.py
+++ b/datalad_gooey/askpass.py
@@ -22,6 +22,7 @@ class GooeyAskPass(Interface):
         from PySide6.QtWidgets import (
             QApplication,
             QInputDialog,
+            QLineEdit
         )
 
         QApplication(sys.argv)
@@ -29,6 +30,7 @@ class GooeyAskPass(Interface):
             None,
             'DataLad Gooey',
             sys.argv[1],
+            echo=QLineEdit.EchoMode.Password
         )
         if not ok:
             sys.exit(2)


### PR DESCRIPTION
This PR fixes #371 

The PR modifies the echo mode of the text entry in `datalad-gooey-askpass`, to "password echo-mode". As a result the entered password is not visible in clear anymore. 

This should be more suitable for demonstrations ;-)