### PR TITLE
Prevent terminal interaction on windows

### DIFF
--- a/datalad_gooey/app.py
+++ b/datalad_gooey/app.py
@@ -113,6 +113,12 @@ class GooeyApp(QObject):
                 'SSH_ASKPASS',
             )
         }
+        if platform.system() == 'Windows':
+            # https://github.com/datalad/datalad-gooey/issues/371
+            # alternative to https://github.com/datalad/datalad-gooey/pull/380
+            self._restore_env['DISPLAY'] = environ.get('DISPLAY')
+            environ['DISPLAY'] = "0:0"
+
         # prevent any terminal-based interaction of Git
         # do it here, not just for command execution to also catch any possible
         # ad-hoc Git calls


### PR DESCRIPTION
This is taking the approach of @christian-monch from https://github.com/datalad/datalad-gooey/pull/380 and broadening its impact to any means of installing datalad-gooey on windows.

Closes datalad/datalad-gooey#371