### PR TITLE
Icon for absent/downloadable state

### DIFF
--- a/datalad_gooey/resource_provider.py
+++ b/datalad_gooey/resource_provider.py
@@ -18,6 +18,7 @@ class GooeyResources:
         'clean': 'clean',
         'modified': 'modified',
         'deleted': 'untracked',
+        'absent': 'absent',
         'unknown': 'untracked',
         'added': 'modified',
         'kaboom': 'kaboom',

--- a/datalad_gooey/resources/icons/absent.svg
+++ b/datalad_gooey/resources/icons/absent.svg
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="106mm" height="106mm" version="1.1" viewBox="0 0 106 106" xml:space="preserve" xmlns="http://www.w3.org/2000/svg"><g transform="translate(-67.5 82.9)" stroke="gray"><circle cx="120" cy="-30" r="42" fill="none" stroke-width="6"/><g transform="translate(6.61 -7.54)" fill="green" stroke-linecap="round" stroke-linejoin="bevel" stroke-width="8"><path d="m131-24.6-16.9 14.8m-17.6-14.8 16.9 14.8m0.407-0.485-0.18-39.3"/><path d="m103 4.64 22.5-0.0376"/></g></g></svg>


### PR DESCRIPTION
It uses the same geometry as "clean" and all others like it.

For now, it is only used for subdatasets. But if `status-light` would report absent annexed files as such (instead of just `clean`), it would automatically be used for those too.

Closes datalad/datalad-gooey#374

![image](https://user-images.githubusercontent.com/136479/196035671-e3caf356-51a0-4bb5-aeee-4f4ea3cf5eab.png)
