### PR TITLE
Fall back to showing full path when `path.name` is empty

### DIFF
--- a/datalad_gooey/fsbrowser_item.py
+++ b/datalad_gooey/fsbrowser_item.py
@@ -68,7 +68,9 @@ class FSBrowserItem(QTreeWidgetItem):
             if self.datalad_type == 'symlink':
                 return f'{self.pathobj.name} -> {self._symlink_target}'
             else:
-                return self.pathobj.name
+                # on windows, show a "drive" would leave `.name` empty
+                return self.pathobj.name \
+                    if self.pathobj.name else str(self.pathobj)
         elif column == 0 and role == Qt.EditRole:
             return self.pathobj.name
         # fall back on default implementation


### PR DESCRIPTION
For an item in the FS tree.

Closes datalad/datalad-gooey#377