### PR TITLE
BF: Fix encoding issue on Windows

### DIFF
--- a/datalad_gooey/history_widget.py
+++ b/datalad_gooey/history_widget.py
@@ -205,6 +205,7 @@ def _run_git(cwd, cmd):
         cmd,
         cwd=cwd,
         protocol=StdOutCapture,
+        encoding="utf-8"
     )
     return out
 


### PR DESCRIPTION
passing an encoding specifically fixes #375 - I suspect that Windows doesn't communicate its preferred encoding, so let's be explicit. Thx to @christian-monch for the pointer.

![image](https://user-images.githubusercontent.com/29738718/198045116-add709fc-4176-4154-b4c6-983df3e06540.png)
