### PR TITLE
Adjust imports deprecated in next 1.0.0 and core 0.18

### DIFF
--- a/datalad_gooey/constraints.py
+++ b/datalad_gooey/constraints.py
@@ -544,7 +544,7 @@ class EnsureCredentialName(EnsureChoice):
         return EnsureChoice(*self._get_choices_(dataset))
 
     def _get_choices_(self, dataset: Dataset = None):
-        from datalad_next.utils.credman import CredentialManager
+        from datalad_next.credman import CredentialManager
         cfgman = dataset.config if dataset else dlcfg
         credman = CredentialManager(cfgman)
         for i in credman.query():

--- a/datalad_gooey/credentials.py
+++ b/datalad_gooey/credentials.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
     QToolButton,
 )
 
-from datalad_next.utils.credman import CredentialManager
+from datalad_next.credman import CredentialManager
 
 from .utils import (
     load_ui,

--- a/datalad_gooey/gooey.py
+++ b/datalad_gooey/gooey.py
@@ -3,12 +3,13 @@
 __docformat__ = 'restructuredtext'
 
 import datalad
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
 from datalad.support.param import Parameter
 from datalad.distribution.dataset import datasetmethod
-from datalad.interface.utils import eval_results
-
 from datalad.interface.results import get_status_dict
 
 import logging

--- a/datalad_gooey/lsdir.py
+++ b/datalad_gooey/lsdir.py
@@ -7,11 +7,13 @@ import stat
 import logging
 from pathlib import Path
 
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
 from datalad.support.param import Parameter
 from datalad.support.exceptions import CapturedException
-from datalad.interface.utils import eval_results
 from datalad.interface.results import get_status_dict
 
 from datalad.runner import (

--- a/datalad_gooey/status_light.py
+++ b/datalad_gooey/status_light.py
@@ -8,10 +8,12 @@ from pathlib import (
     PurePosixPath,
 )
 
-from datalad.interface.base import Interface
-from datalad.interface.base import build_doc
+from datalad.interface.base import (
+    Interface,
+    build_doc,
+    eval_results,
+)
 from datalad.support.param import Parameter
-from datalad.interface.utils import eval_results
 from datalad.dataset.gitrepo import GitRepo
 from datalad.distribution.dataset import (
     EnsureDataset,


### PR DESCRIPTION
Changes imports of `CredentialManager` (from next) and `eval_results` to match their current locations. Closes #427 