### PR TITLE
Doc build: update intersphinx_mapping

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,7 +116,7 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
@@ -114,9 +113,6 @@ pygments_style = 'sphinx'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
The "old" format of intersphinx_mapping is deprecated since Sphinx 6.2 and started causing warnings treated as errors in the doc build GitHub action (but not Read The Docs, as it currently uses Sphinx v5.3.0) in #428 

This PR removes the use of `intersphinx` extension and `intersphinx_mapping` config option, as it was an unused placeholder from the extension template (see similar removal in https://github.com/datalad/datalad-next/commit/a1f3af9f4e82f9b4ded9aa4cbcc2df8e3c0f1976).

This PR can be made less invasive by reverting the last commit and keeping `intersphinx` with an updated `intersphinx_mapping`.

For reference: 
https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html