### PR TITLE
Bump update-contributors workflow action

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Tributors Update
-        uses: con/tributors@0.0.21
+        uses: con/tributors@0.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
A recent attempt to update contributors failed: https://github.com/datalad/datalad-gooey/actions/runs/6081095092/job/16496097252. I'm unsure whether bumping the action solves it, but this makes the version used here match the version used in datalad-core.